### PR TITLE
Add Dockerfile.dev that builds stellar-core and horizon from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Docker Cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/docker-cache
+        key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-docker-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-docker-${{ github.ref }}-
+          ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-docker-
+
+    - name: Docker Images - Load from Cache
+      continue-on-error: true
+      run: docker load -i /tmp/docker-cache/images.tar
+
     - name: Build Stellar-Core Image
       if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}
       run: DOCKER_BUILDKIT=0 docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
@@ -49,3 +62,7 @@ jobs:
         echo "supervisorctl tail -f stellar-core" | docker exec -i stellar sh &
         echo "supervisorctl tail -f horizon" | docker exec -i stellar sh &
         go run test.go
+
+    - name: Docker Images - Save to Cache
+      continue-on-error: true
+      run: docker save $(docker images -q) -o /tmp/docker-cache/images.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       run: docker load -i /tmp/stellar-horizon/image
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t stellar/quickstart -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.dev -t stellar/quickstart -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Docker Cache
       uses: actions/cache@v2
       with:
-        path: /tmp/docker-cache
+        path: /tmp/docker-images.tar
         key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-docker-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-docker-${{ github.ref }}-
@@ -33,7 +33,7 @@ jobs:
 
     - name: Docker Images - Load from Cache
       continue-on-error: true
-      run: docker load -i /tmp/docker-cache/images.tar
+      run: docker load -i /tmp/docker-images.tar
 
     - name: Build Stellar-Core Image
       if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}
@@ -65,4 +65,4 @@ jobs:
 
     - name: Docker Images - Save to Cache
       continue-on-error: true
-      run: docker save $(docker images -q) -o /tmp/docker-cache/images.tar
+      run: docker save $(docker images -q) -o /tmp/docker-images.tar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Build Stellar-Core Image
       if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}
-      run: docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: DOCKER_BUILDKIT=0 docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 
     - name: Build Stellar-Horizon Image
       if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        dockerfile: [Dockerfile, Dockerfile.testing]
+        dockerfile: [Dockerfile, Dockerfile.testing, Dockerfile.dev]
         options: ["", --enable-horizon-captive-core]
         exclude:
           - network: testnet
@@ -22,11 +22,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Build Stellar-Core Image
+      if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}
+      run: docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+
+    - name: Build Stellar-Horizon Image
+      if: ${{ matrix.dockerfile == 'Dockerfile.dev' }}
+      run: docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
+
     - name: Build Quickstart Image
-      run: docker build -f ${{ matrix.dockerfile }} -t stellar-quickstart .
+      run: docker build -t stellar/quickstart -f ${{ matrix.dockerfile }} .
 
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart --${{ matrix.network }} ${{ matrix.options }}
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
     - name: Build Quickstart Image
       run: docker build -f Dockerfile.dev -t stellar/quickstart:dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core --build-arg HORIZON_IMAGE_REF=stellar-horizon
     - name: Save Quickstart Image
-      run: docker save stellar-quickstart:dev -o /tmp/image
+      run: docker save stellar/quickstart:dev -o /tmp/image
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -116,7 +116,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -152,7 +152,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart:testing --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart:testing --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -188,7 +188,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart:dev --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart:dev --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -201,4 +201,3 @@ jobs:
         echo "supervisorctl tail -f horizon" | docker exec -i stellar sh &
         go run test.go
         curl http://localhost:8000
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,52 @@ jobs:
         name: image-Dockerfile-testing
         path: /tmp/image
 
-  build-Dockerfile-dev:
+  build-stellar-core:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: DOCKER_BUILDKIT=0 docker build -f docker/Dockerfile.testing -t stellar/stellar-core:testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar/stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+    - name: Upload Stellar-Core Image
+      uses: actions/upload-artifact@v2
+      with:
+        name: image-stellar-core
+        path: /tmp/image
+
+  build-stellar-horizon:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Horizon Image
-      run: docker build -f services/horizon/docker/Dockerfile.dev -t stellar/stellar-horizon:dev git://github.com/stellar/go#master
+      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar/stellar-horizon:dev -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
+    - name: Upload Stellar-Horizon Image
+      uses: actions/upload-artifact@v2
+      with:
+        name: image-stellar-horizon
+        path: /tmp/image
+
+  build-Dockerfile-dev:
+    needs: [build-stellar-core, build-stellar-horizon]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download Stellar-Core Image
+      uses: actions/download-artifact@v2
+      with:
+        name: image-stellar-core
+        path: /tmp/stellar-core
+    - name: Download Stellar-Horizon Image
+      uses: actions/download-artifact@v2
+      with:
+        name: image-stellar-horizon
+        path: /tmp/stellar-horizon
+    - name: Load Stellar-Core Image
+      run: docker load -i /tmp/stellar-core/image
+    - name: Load Stellar-Horizon Image
+      run: docker load -i /tmp/stellar-horizon/image
+    - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
       run: docker buildx build -f Dockerfile.testing -t stellar/quickstart -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar/stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar/stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,16 @@ jobs:
       run: docker load -i /tmp/stellar-core/image
     - name: Load Stellar-Horizon Image
       run: docker load -i /tmp/stellar-horizon/image
-    - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
+    # Docker buildx cannot be used to build the dev quickstart image because
+    # buildx does not yet support importing existing images, like the core and
+    # horizon images above, into a buildx builder's cache. Buildx would be
+    # preferred because it can output a smaller image file faster than docker
+    # save can.  Once buildx supports it we can update.
+    # https://github.com/docker/buildx/issues/847
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.dev -t stellar-quickstart:dev -o type=docker,dest=/tmp/image .
+      run: docker build -f Dockerfile.dev -t stellar-quickstart:dev .
+    - name: Save Quickstart Image
+      run: docker save stellar-quickstart:dev -o /tmp/image
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile -t stellar-quickstart -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile -t stellar/quickstart -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t stellar-quickstart:testing -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.testing -t stellar/quickstart:testing -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Horizon Image
-      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon:dev -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
+      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
     - name: Upload Stellar-Horizon Image
       uses: actions/upload-artifact@v2
       with:
@@ -85,7 +85,7 @@ jobs:
     # save can.  Once buildx supports it we can update.
     # https://github.com/docker/buildx/issues/847
     - name: Build Quickstart Image
-      run: docker build -f Dockerfile.dev -t stellar-quickstart:dev .
+      run: docker build -f Dockerfile.dev -t stellar/quickstart:dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core --build-arg HORIZON_IMAGE_REF=stellar-horizon
     - name: Save Quickstart Image
       run: docker save stellar-quickstart:dev -o /tmp/image
     - name: Upload Quickstart Image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile -t stellar/quickstart -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile -t stellar-quickstart -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t stellar/quickstart -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.testing -t stellar-quickstart:testing -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar/stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core:testing -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Horizon Image
-      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar/stellar-horizon:dev -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
+      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon:dev -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
     - name: Upload Stellar-Horizon Image
       uses: actions/upload-artifact@v2
       with:
@@ -80,7 +80,7 @@ jobs:
       run: docker load -i /tmp/stellar-horizon/image
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.dev -t stellar/quickstart -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.dev -t stellar-quickstart:dev -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -109,7 +109,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -145,7 +145,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart:testing --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -181,7 +181,7 @@ jobs:
     - name: Load Quickstart Image
       run: docker load -i /tmp/image
     - name: Run Quickstart Image
-      run: docker run --rm -d -p "8000:8000" --name stellar stellar/quickstart --${{ matrix.network }} ${{ matrix.options }}
+      run: docker run --rm -d -p "8000:8000" --name stellar stellar-quickstart:dev --${{ matrix.network }} ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,39 @@
+FROM ubuntu:20.04
+
+MAINTAINER Bartek Nowotarski <bartek@stellar.org>
+
+EXPOSE 5432
+EXPOSE 8000
+EXPOSE 6060
+EXPOSE 11625
+EXPOSE 11626
+
+ADD dependencies /
+RUN ["chmod", "+x", "dependencies"]
+RUN /dependencies
+
+# Requires building the testing image of stellar-core. See Makefile.
+RUN apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
+COPY --from=stellar/stellar-core:testing /usr/local/bin/stellar-core /usr/bin/stellar-core
+
+# Requires building the dev image of stellar-horizon. See Makefile.
+COPY --from=stellar/stellar-horizon:dev /horizon /usr/bin/stellar-horizon
+
+RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
+
+RUN ["mkdir", "-p", "/opt/stellar"]
+RUN ["touch", "/opt/stellar/.docker-ephemeral"]
+
+RUN ["ln", "-s", "/opt/stellar", "/stellar"]
+RUN ["ln", "-s", "/opt/stellar/core/etc/stellar-core.cfg", "/stellar-core.cfg"]
+RUN ["ln", "-s", "/opt/stellar/horizon/etc/horizon.env", "/horizon.env"]
+ADD common /opt/stellar-default/common
+ADD pubnet /opt/stellar-default/pubnet
+ADD testnet /opt/stellar-default/testnet
+ADD standalone /opt/stellar-default/standalone
+
+
+ADD start /
+RUN ["chmod", "+x", "start"]
+
+ENTRYPOINT ["/start"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,10 +14,10 @@ RUN /dependencies
 
 # Requires building the testing image of stellar-core. See Makefile.
 RUN apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
-COPY --from=stellar/stellar-core:testing /usr/local/bin/stellar-core /usr/bin/stellar-core
+COPY --from=stellar-core:testing /usr/local/bin/stellar-core /usr/bin/stellar-core
 
 # Requires building the dev image of stellar-horizon. See Makefile.
-COPY --from=stellar/stellar-horizon:dev /horizon /usr/bin/stellar-horizon
+COPY --from=stellar-horizon:dev /horizon /usr/bin/stellar-horizon
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,10 @@
-FROM ubuntu:20.04
+ARG STELLAR_CORE_IMAGE_REF
+ARG HORIZON_IMAGE_REF
 
-MAINTAINER Bartek Nowotarski <bartek@stellar.org>
+FROM $STELLAR_CORE_IMAGE_REF AS stellar-core
+FROM $HORIZON_IMAGE_REF AS horizon
+
+FROM ubuntu:20.04
 
 EXPOSE 5432
 EXPOSE 8000
@@ -12,12 +16,10 @@ ADD dependencies /
 RUN ["chmod", "+x", "dependencies"]
 RUN /dependencies
 
-# Requires building the testing image of stellar-core. See Makefile.
 RUN apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
-COPY --from=stellar-core:testing /usr/local/bin/stellar-core /usr/bin/stellar-core
+COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 
-# Requires building the dev image of stellar-horizon. See Makefile.
-COPY --from=stellar-horizon:dev /horizon /usr/bin/stellar-horizon
+COPY --from=horizon /horizon /usr/bin/stellar-horizon
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
-	docker build -t stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
+	docker build -t stellar-core:master -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 
 build-dev: build-dev-deps
-	docker build -t stellar/quickstart:dev -f Dockerfile.dev .
+	docker build -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:master --build-arg HORIZON_IMAGE_REF=stellar-horizon:master

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
-	# Buildkit is disabled because of https://github.com/moby/buildkit/issues/2463.
-	DOCKER_BUILDKIT=0 docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 
 build-dev: build-dev-deps

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-__PHONY__: build build-testing
+__PHONY__: build build-testing build-dev
 
 build:
 	docker build -t stellar/quickstart -f Dockerfile .
 
 build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
+
+build-dev:
+	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#cap21and40 --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#cap21and40
+	docker build -t stellar/quickstart:dev -f Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev:
-	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev:
-	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#cap21and40 --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#cap21and40
+	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core-experimental-cap21and40#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__PHONY__: build build-testing build-dev
+__PHONY__: build build-testing build-dev build-dev-deps
 
 build:
 	docker build -t stellar/quickstart -f Dockerfile .
@@ -6,8 +6,10 @@ build:
 build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
-build-dev:
+build-dev-deps:
 	# Buildkit is disabled because of https://github.com/moby/buildkit/issues/2463.
 	DOCKER_BUILDKIT=0 docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
+
+build-dev: build-dev-deps
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
-	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
+	docker build -t stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 
 build-dev: build-dev-deps
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev .

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev:
-	docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	# Buildkit is disabled because of https://github.com/moby/buildkit/issues/2463.
+	DOCKER_BUILDKIT=0 docker build -t stellar/stellar-core:testing -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 	docker build -t stellar/stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev .


### PR DESCRIPTION
### What
Add a `Dockerfile.dev` dockerfile that builds `stellar-core` and `stellar-horizon` from source and uses those source builds in the quickstart image built.

Add a ci workflow that exercises the new `Dockerfile.dev`:

<img width="1452" alt="Screen Shot 2021-11-16 at 3 26 35 PM" src="https://user-images.githubusercontent.com/351529/142082506-13ae7add-9ee0-482a-9790-d607b5b7adad.png">

### Why
While working on the CAP-21 and CAP-40 fork of stellar-core and stellar-horizon I found it helpful to be able to build a quickstart image that had updates without having to rebuild debs, because the deb build process is extremely slow and complete, and involves fiddling with a very complicated and confusing Jenkins setup.

Both stellar-core and stellar-horizon have dockerfiles in their repos that build from source. Stellar-core has `Dockerfile.testing` and Stellar-Horizon has `Dockerfile.dev`. We can leverage those dockerfiles to build a quickstart from source.
