### PR TITLE
Increase timeout for test to 2 hours

### DIFF
--- a/test.go
+++ b/test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const timeout = 1 * time.Hour
+const timeout = 2 * time.Hour
 
 type Root struct {
 	HorizonSequence int32 `json:"history_latest_ledger"`


### PR DESCRIPTION
### What
Increase the timeout on the test that runs in CI to 2 hours.

### Why
The test is frequently timing out on CI runs for pubnet. According to logs I'm looking at across multiple PRs that have failed consistently it seems like it's just taking a long time to catch up ingesting.

The scale of the data in pubnet and it's difficulty for us to even run a simple test in the quickstart image with it could be a more motivation for us to stop supporting pubnet in this quickstart image (#305). Regardless of whether we do that though, upping this timeout should give us confirmation if it truly just needs more time.