### PR TITLE
Cancel superseded builds for non-protected branches

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -5,6 +5,10 @@ on:
     branches: master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-stellar-core:

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -9,6 +9,10 @@ on:
     # UTC-8: At 02:15 on every day-of-week from Monday through Friday.
     - cron: '15 10 * * 1-5'
 
+# Prevent more than one build of this workflow for a branch to be running at the
+# same time, and if multiple are queued, only run the latest, cancelling any
+# already running build. The exception being any protected branch, such as
+# master, where a build for every commit will run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -5,6 +5,10 @@ on:
     branches: master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -5,6 +5,10 @@ on:
     branches: master
   pull_request:
 
+# Prevent more than one build of this workflow for a branch to be running at the
+# same time, and if multiple are queued, only run the latest, cancelling any
+# already running build. The exception being any protected branch, such as
+# master, where a build for every commit will run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -5,6 +5,10 @@ on:
     branches: master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -5,6 +5,10 @@ on:
     branches: master
   pull_request:
 
+# Prevent more than one build of this workflow for a branch to be running at the
+# same time, and if multiple are queued, only run the latest, cancelling any
+# already running build. The exception being any protected branch, such as
+# master, where a build for every commit will run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### What
Cancel builds for non-protected (non-master) branches and pull requests when a new build is pushed to the branch.

### Why
The builds in this repo take a long time and when iterating on a PR it would be ideal if only the latest commit runs a build.

For protected branches, like the master branch, we should probably still have the build run on every commit so we know if it is or was broken at any point.