### PR TITLE
Cache the stellar-core image in the Dockerfile.dev build

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -26,7 +26,7 @@ jobs:
           docker-${{ github.workflow }}-${{ github.ref }}-
           docker-${{ github.workflow }}-
     - name: Build Stellar-Core Image
-      run: docker buildx build --pull -f docker/Dockerfile.testing -t stellar-core --cache-from type=local,src=/tmp/docker-cache --cache-to type=local,dest=/tmp/docker-cache-new -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build --pull -f docker/Dockerfile.testing -t stellar-core --cache-from type=local,src=/tmp/docker-cache --cache-to type=local,dest=/tmp/docker-cache-new,mode=max -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -22,7 +22,9 @@ jobs:
         path: /tmp/docker-cache
         key: docker-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-
+          docker-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+          docker-${{ github.workflow }}-${{ github.ref }}-
+          docker-${{ github.workflow }}-
     - name: Build Stellar-Core Image
       run: docker buildx build --pull -f docker/Dockerfile.testing -t stellar-core --cache-from type=local,src=/tmp/docker-cache --cache-to type=local,dest=/tmp/docker-cache-new -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -16,13 +16,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
+    - name: Cache Stellar-Core Image Layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/docker-cache
+        key: docker-${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build --pull -f docker/Dockerfile.testing -t stellar-core --cache-from type=local,src=/tmp/docker-cache --cache-to type=local,dest=/tmp/docker-cache-new -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:
         name: image-stellar-core
         path: /tmp/image
+    - name: Update Cache for Storage
+      run: rm -rf /tmp/docker-cache && mv /tmp/docker-cache-new /tmp/docker-cache
 
   build-stellar-horizon:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
Cache the stellar-core image in the Dockerfile.dev build.

### Why
The image takes a while to build, and many builds in this repo will build the same image over and over, so caching the layers for that image reduces build time. We could cache all the images, but the other images are all really fast so there's little value in crowding the ymls to add it for the others.