### PR TITLE
Remove options from stellar-core when building for the dev image

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
### What
Remove the custom options used in building stellar-core.

### Why
They speed up compilation by about 7 mins, but slow down the tests by almost 1 hour. Clearly they weren't worth it!