### PR TITLE
Add workflow dispatch trigger to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,7 @@
 name: 'Stale Issues'
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 18 * * *' # approx 9:30am daily
 


### PR DESCRIPTION
### What
Add workflow dispatch trigger to stale workflow.

### Why
To allow us to manually trigger it. So I can trigger it and test it.