### PR TITLE
Fix image url in statuses

### DIFF
--- a/.github/actions/push/action.yml
+++ b/.github/actions/push/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash
       run: echo "IMAGE_URL=https://${{ inputs.image }}" >> $GITHUB_ENV
     -
-      if: ${{ steps.image_parts.outputs.registry == 'docker.io' }}
+      if: ${{ inputs.registry == 'docker.io' }}
       shell: bash
       run: |
         echo "IMAGE_URL=https://hub.docker.com/r/${{ steps.image_parts.outputs.repo }}/tags?name=${{ steps.image_parts.outputs.tag }}" >> $GITHUB_ENV


### PR DESCRIPTION

Fix the image URL that is posted to GitHub commit statuses so it is correctly set for Docker Hub.