### PR TITLE
Include revision label on testing image

### DIFF
--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -28,7 +28,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t $IMAGE -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.testing -t --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" $IMAGE -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -28,7 +28,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" $IMAGE -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.testing -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
### What
Include the git revision on the testing image in the same way it is included on the latest and dev images.

### Why
It makes it trivial to look at an image and know which commit of the repo the image was built from. It is something we have on the latest image and the dev image, and I missed it on the testing image.