### PR TITLE
Fix failing master build

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Core Image
-      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS='--disable-tests'
+      run: docker buildx build -f docker/Dockerfile.testing -t stellar-core -o type=docker,dest=/tmp/image https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS='--disable-tests'
     - name: Upload Stellar-Core Image
       uses: actions/upload-artifact@v2
       with:
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Horizon Image
-      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
+      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#master
     - name: Upload Stellar-Horizon Image
       uses: actions/upload-artifact@v2
       with:
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Friendbot Image
-      run: docker buildx build -f services/friendbot/docker/Dockerfile -t stellar-friendbot -o type=docker,dest=/tmp/image git://github.com/stellar/go#master
+      run: docker buildx build -f services/friendbot/docker/Dockerfile -t stellar-friendbot -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#master
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ build-testing:
 	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
-	docker build -t stellar-core:master -f docker/Dockerfile.testing git://github.com/stellar/stellar-core#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev git://github.com/stellar/go#master
-	docker build -t stellar-friendbot:master -f services/friendbot/docker/Dockerfile git://github.com/stellar/go#master
+	docker build -t stellar-core:master -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev https://github.com/stellar/go.git#master
+	docker build -t stellar-friendbot:master -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#master
 
 build-dev: build-dev-deps
 	docker build -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:master --build-arg HORIZON_IMAGE_REF=stellar-horizon:master --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:master


### PR DESCRIPTION
### What
Use https:// instead of git:// for git docker builds.

### Why
The main trigger for this change is that GitHub stopped supporting `git://` yesterday because it is insecure. I should never have used `git://` because it is insecure, so this is a good change regardless.

This change has no functional impact on the build.

Note the `.git` is required on the tail of the URL as Docker/Podman use it on the URL to identify that this is a git repo and not a tar download.