### PR TITLE
Make Dockerfile.dev build natively on arm64

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Horizon Image
-      run: docker buildx build -f services/horizon/docker/Dockerfile.dev -t stellar-horizon -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#master
+      run: docker buildx build -f services/horizon/docker/Dockerfile.dev --target builder -t stellar-horizon -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#master
     - name: Upload Stellar-Horizon Image
       uses: actions/upload-artifact@v2
       with:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,7 @@ RUN /dependencies
 RUN apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
 COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 
-COPY --from=horizon /horizon /usr/bin/stellar-horizon
+COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
 
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-testing:
 
 build-dev-deps:
 	docker build -t stellar-core:master -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev https://github.com/stellar/go.git#master
+	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#master
 	docker build -t stellar-friendbot:master -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#master
 
 build-dev: build-dev-deps


### PR DESCRIPTION
### What
Build only Horizon's `builder` stage when building the dependencies for Dockerfile.dev.

### Why
Horizon's dockerfile builds more than Horizon, it also installs and sets up stellar-core, because that is a dependency of Horizon if you choose to run Horizon that way. The Dockerfile.dev image uses the Horizon dockerfile to build Horizon, and doesn't actually need any other applications that the Horizon dockerfile installs. Docker makes it trivial with multi-stage builds to build only specific stages, which is useful when one needs to run the stages that build an application but don't need the stages for running the application. This strategy is useful here since we only need to build Horizon, not run it from the image.

The same pattern could be employed for the other services, stellar-core and friendbot, but is not needed at this time.

The underlying reason I needed this is so that I can build the quickstart image natively on arm64. When building on arm64 without this change the install of stellar-core fails in the Horizon dockerfile.