### PR TITLE
Update makefile to always build on amd64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 __PHONY__: build build-testing build-dev build-dev-deps
 
 build:
-	docker build -t stellar/quickstart -f Dockerfile .
+	docker build --platform linux/amd64 -t stellar/quickstart -f Dockerfile .
 
 build-testing:
-	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
+	docker build --platform linux/amd64 -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
 	docker build -t stellar-core:master -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'


### PR DESCRIPTION
### What
Update `Makefile` to always build the main and testing builds with the `linux/amd64` platform.

### Why
For developers on other architectures these make commands fail because stellar-core is only available for install via deb for amd64.

Apple Silicon computers are becoming more prevalent and are arm64.