### PR TITLE
Use 0.5native base reserve in standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 __PHONY__: build build-testing build-dev build-dev-deps
 
 build:
-	docker build -t stellar/quickstart -f Dockerfile .
+	docker build --platform linux/amd64 -t stellar/quickstart -f Dockerfile .
 
 build-testing:
-	docker build -t stellar/quickstart:testing -f Dockerfile.testing .
+	docker build --platform linux/amd64 -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
 	docker build -t stellar-core:master -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'

--- a/start
+++ b/start
@@ -361,7 +361,7 @@ EOF
 }
 
 function upgrade_standalone() {
-  # Upgrade standalone network's protocol version
+  # Upgrade standalone network's protocol version and base reserve to match pubnet/testnet
   if [ "$NETWORK" = "standalone" ]; then
     # Wait for server
     while ! echo "Stellar-core http server listening!" | nc localhost 11626 &> /dev/null; do sleep 1; done
@@ -371,7 +371,7 @@ function upgrade_standalone() {
     fi
     if [ ".$PROTOCOL_VERSION" != ".none" ] ; then
       if [ $PROTOCOL_VERSION -gt 0 ]; then
-        curl "http://localhost:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=$PROTOCOL_VERSION"
+        curl "http://localhost:11626/upgrades?mode=set&upgradetime=1970-01-01T00:00:00Z&protocolversion=$PROTOCOL_VERSION&basereserve=5000000"
       fi
     fi
   fi


### PR DESCRIPTION
### What
Use 0.5 native base reserve in standalone.

### Why
Standalone mode uses the original base reserve the network had back at the first protocol, which was 10 native. Pubnet and testnet use 0.5 native because at some point the base reserve was reduced. Having standalone have a higher one is inconvenient for testing and doesn't really add any value.

Close #343