### PR TITLE
Adding soroban-rpc service to quickstart for standalone network

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -60,8 +60,20 @@ jobs:
         name: image-stellar-friendbot
         path: /tmp/image
 
+  build-stellar-soroban-rpc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
+    - name: Build Stellar-Soraban-Rpc Image
+      run: docker buildx build -f exp/services/soroban-rpc/docker/Dockerfile -t stellar-soroban-rpc -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#master
+    - name: Upload Stellar-Friendbot Image
+      uses: actions/upload-artifact@v2
+      with:
+        name: image-stellar-friendbot
+        path: /tmp/image      
+
   build:
-    needs: [build-stellar-core, build-stellar-horizon, build-stellar-friendbot]
+    needs: [build-stellar-core, build-stellar-horizon, build-stellar-friendbot, build-stellar-soroban-rpc]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -82,12 +94,19 @@ jobs:
       with:
         name: image-stellar-friendbot
         path: /tmp/stellar-friendbot
+    - name: Download Stellar-Soraban-Rpc Image
+      uses: actions/download-artifact@v2
+      with:
+        name: image-stellar-soroban-rpc
+        path: /tmp/stellar-soroban-rpc 
     - name: Load Stellar-Core Image
       run: docker load -i /tmp/stellar-core/image
     - name: Load Stellar-Horizon Image
       run: docker load -i /tmp/stellar-horizon/image
     - name: Load Stellar-Friendbot Image
       run: docker load -i /tmp/stellar-friendbot/image
+    - name: Load Stellar-Soraban-Rpc Image
+      run: docker load -i /tmp/stellar-soroban-rpc/image  
     # Docker buildx cannot be used to build the dev quickstart image because
     # buildx does not yet support importing existing images, like the core and
     # horizon images above, into a buildx builder's cache. Buildx would be
@@ -95,7 +114,7 @@ jobs:
     # save can.  Once buildx supports it we can update.
     # https://github.com/docker/buildx/issues/847
     - name: Build Quickstart Image
-      run: docker build -f Dockerfile.dev -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core --build-arg HORIZON_IMAGE_REF=stellar-horizon --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot
+      run: docker build -f Dockerfile.dev -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core --build-arg HORIZON_IMAGE_REF=stellar-horizon --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc
     - name: Save Quickstart Image
       run: docker save $IMAGE -o /tmp/image
     - name: Upload Quickstart Image
@@ -109,12 +128,12 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        options: ["", --enable-horizon-captive-core]
+        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
           - network: pubnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -153,14 +172,15 @@ jobs:
         go run test_horizon_ingesting.go
         curl http://localhost:8000
     - name: Run friendbot test
-      # Horizon with captive-core is currently broken. Don't run the Friendbot
-      # test in captive-core mode since it will always fail while Horizon is not
-      # functioning with captive-core.
-      # See https://github.com/stellar/quickstart/issues/328 for more details.
-      if: ${{ matrix.network == 'standalone' && !contains(matrix.options, '--enable-horizon-captive-core') }}
+      if: ${{ matrix.network == 'standalone' }}
       run: |
         echo "supervisorctl tail -f friendbot" | docker exec -i stellar sh &
         go run test_friendbot.go
+    - name: Run soroban rpc test
+      if: ${{ matrix.network == 'standalone' && contains(matrix.options, '--enable-soroban-rpc') }}
+      run: |
+        echo "supervisorctl tail -f soroban-rpc" | docker exec -i stellar sh &
+        go run test_soroban_rpc_up.go    
 
   push:
     # Push image to registry after build for pull requests from a local branch.

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -131,9 +131,9 @@ jobs:
         options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
           - network: pubnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -131,9 +131,13 @@ jobs:
         options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
+            options: "--enable-horizon-captive-core"
+          - network: testnet
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
           - network: pubnet
-            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
+            options: "--enable-horizon-captive-core"
+          - network: pubnet
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
+        options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
             options: "--enable-horizon-captive-core --enable-soroban-rpc"

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:
-        name: image-stellar-friendbot
+        name: image-stellar-soroban-rpc
         path: /tmp/image      
 
   build:

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
+        options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
             options: "--enable-horizon-captive-core --enable-soroban-rpc"

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -17,7 +17,7 @@ concurrency:
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-testing', github.event.pull_request.number) || 'testing') }}
-
+  SOROBAN_RPC_VERSION: latest
 jobs:
 
   build:
@@ -28,7 +28,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile.testing -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image SOROBAN_RPC_VERSION="${{ env.SOROBAN_RPC_VERSION }}" .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -28,7 +28,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile.testing -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image SOROBAN_RPC_VERSION="${{ env.SOROBAN_RPC_VERSION }}" .
+      run: docker buildx build -f Dockerfile.testing -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image --build-arg SOROBAN_RPC_VERSION="${{ env.SOROBAN_RPC_VERSION }}" .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -43,9 +43,13 @@ jobs:
         options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
+            options: "--enable-horizon-captive-core"
+          - network: testnet
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
           - network: pubnet
-            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
+            options: "--enable-horizon-captive-core"
+          - network: pubnet
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -43,9 +43,9 @@ jobs:
         options: ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
           - network: pubnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: ["--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-soroban-rpc"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -40,12 +40,12 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        options: ["", --enable-horizon-captive-core]
+        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
           - network: pubnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -84,14 +84,15 @@ jobs:
         go run test_horizon_ingesting.go
         curl http://localhost:8000
     - name: Run friendbot test
-      # Horizon with captive-core is currently broken. Don't run the Friendbot
-      # test in captive-core mode since it will always fail while Horizon is not
-      # functioning with captive-core.
-      # See https://github.com/stellar/quickstart/issues/328 for more details.
-      if: ${{ matrix.network == 'standalone' && !contains(matrix.options, '--enable-horizon-captive-core') }}
+      if: ${{ matrix.network == 'standalone' }}
       run: |
         echo "supervisorctl tail -f friendbot" | docker exec -i stellar sh &
         go run test_friendbot.go
+    - name: Run soroban rpc test
+      if: ${{ matrix.network == 'standalone' && contains(matrix.options, '--enable-soroban-rpc') }}
+      run: |
+        echo "supervisorctl tail -f soroban-rpc" | docker exec -i stellar sh &
+        go run test_soroban_rpc_up.go        
 
   push:
     # Push image to registry after build for pull requests from a local branch.

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest') }}
+  SOROBAN_RPC_VERSION: latest 
 
 jobs:
   build:
@@ -27,7 +28,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image .
+      run: docker buildx build -f Dockerfile -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image --build-arg SOROBAN_RPC_VERSION="${{ env.SOROBAN_RPC_VERSION }}" .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -39,12 +39,12 @@ jobs:
     strategy:
       matrix:
         network: [testnet, pubnet, standalone]
-        options: ["", --enable-horizon-captive-core]
+        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
         exclude:
           - network: testnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
           - network: pubnet
-            options: --enable-horizon-captive-core
+            options: "--enable-horizon-captive-core --enable-soroban-rpc"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -83,14 +83,15 @@ jobs:
         go run test_horizon_ingesting.go
         curl http://localhost:8000
     - name: Run friendbot test
-      # Horizon with captive-core is currently broken. Don't run the Friendbot
-      # test in captive-core mode since it will always fail while Horizon is not
-      # functioning with captive-core.
-      # See https://github.com/stellar/quickstart/issues/328 for more details.
-      if: ${{ matrix.network == 'standalone' && !contains(matrix.options, '--enable-horizon-captive-core') }}
+      if: ${{ matrix.network == 'standalone' }}
       run: |
         echo "supervisorctl tail -f friendbot" | docker exec -i stellar sh &
         go run test_friendbot.go
+    - name: Run soroban rpc test
+      if: ${{ matrix.network == 'standalone' && contains(matrix.options, '--enable-soroban-rpc') }}
+      run: |
+        echo "supervisorctl tail -f soroban-rpc" | docker exec -i stellar sh &
+        go run test_soroban_rpc_up.go    
 
   push:
     # Push image to registry after build for pull requests from a local branch.

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -16,8 +16,7 @@ concurrency:
 
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest') }}
-  SOROBAN_RPC_VERSION: latest 
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest') }} 
 
 jobs:
   build:
@@ -28,7 +27,7 @@ jobs:
         ref: ${{ env.HEAD_SHA }}
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Quickstart Image
-      run: docker buildx build -f Dockerfile -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image --build-arg SOROBAN_RPC_VERSION="${{ env.SOROBAN_RPC_VERSION }}" .
+      run: docker buildx build -f Dockerfile -t $IMAGE --label org.opencontainers.image.revision="${{ env.HEAD_SHA }}" -o type=docker,dest=/tmp/image .
     - name: Upload Quickstart Image
       uses: actions/upload-artifact@v2
       with:
@@ -39,13 +38,14 @@ jobs:
     needs: build
     strategy:
       matrix:
+        # TODO, add futurenet and --enable-soroban-rpc to matrix of test cases
         network: [testnet, pubnet, standalone]
-        options: ["", "--enable-horizon-captive-core --enable-soroban-rpc"]
+        options: ["", "--enable-horizon-captive-core"]
         exclude:
           - network: testnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: "--enable-horizon-captive-core"
           - network: pubnet
-            options: "--enable-horizon-captive-core --enable-soroban-rpc"
+            options: "--enable-horizon-captive-core"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -88,11 +88,12 @@ jobs:
       run: |
         echo "supervisorctl tail -f friendbot" | docker exec -i stellar sh &
         go run test_friendbot.go
-    - name: Run soroban rpc test
-      if: ${{ matrix.network == 'standalone' && contains(matrix.options, '--enable-soroban-rpc') }}
-      run: |
-        echo "supervisorctl tail -f soroban-rpc" | docker exec -i stellar sh &
-        go run test_soroban_rpc_up.go    
+    # TODO, test soroban once released    
+    # - name: Run soroban rpc test
+    #  if: ${{ matrix.network == 'standalone' && contains(matrix.options, '--enable-soroban-rpc') }}
+    #  run: |
+    #    echo "supervisorctl tail -f soroban-rpc" | docker exec -i stellar sh &
+    #    go run test_soroban_rpc_up.go    
 
   push:
     # Push image to registry after build for pull requests from a local branch.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 ARG STELLAR_CORE_VERSION=19.3.0-1006.9ce6dc4e9.focal
 ARG HORIZON_VERSION=2.20.0-296
 ARG FRIENDBOT_VERSION=horizon-v2.20.0
+ARG SOROBAN_RPC_VERSION=horizon-v2.20.0
 
 FROM golang:1.19 as go
 
 ARG FRIENDBOT_VERSION
 
 RUN go install github.com/stellar/go/services/friendbot@$FRIENDBOT_VERSION
+RUN go install github.com/stellar/go/exp/services/soroban-rpc$SOROBAN_RPC_VERSION
 
 FROM ubuntu:20.04
 
@@ -29,6 +31,7 @@ ADD install /
 RUN ["chmod", "+x", "install"]
 RUN /install
 COPY --from=go /go/bin/friendbot /usr/local/bin/friendbot
+COPY --from=go /go/bin/soroban-rpc /usr/local/bin/soroban-rpc
 
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ ARG SOROBAN_RPC_VERSION=horizon-v2.20.0
 FROM golang:1.19 as go
 
 ARG FRIENDBOT_VERSION
+ARG SOROBAN_RPC_VERSION
 
 RUN go install github.com/stellar/go/services/friendbot@$FRIENDBOT_VERSION
-RUN go install github.com/stellar/go/exp/services/soroban-rpc$SOROBAN_RPC_VERSION
+RUN go install github.com/stellar/go/exp/services/soroban-rpc@$SOROBAN_RPC_VERSION
 
 FROM ubuntu:20.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 ARG STELLAR_CORE_VERSION=19.3.0-1006.9ce6dc4e9.focal
 ARG HORIZON_VERSION=2.20.0-296
 ARG FRIENDBOT_VERSION=horizon-v2.20.0
-ARG SOROBAN_RPC_VERSION=horizon-v2.20.0
+# TODO, when soroban-rpc is released
+# ARG SOROBAN_RPC_VERSION=x.y.z
 
 FROM golang:1.19 as go
 
 ARG FRIENDBOT_VERSION
-ARG SOROBAN_RPC_VERSION
+#ARG SOROBAN_RPC_VERSION
 
 RUN go install github.com/stellar/go/services/friendbot@$FRIENDBOT_VERSION
-RUN go install github.com/stellar/go/exp/services/soroban-rpc@$SOROBAN_RPC_VERSION
+#RUN go install github.com/stellar/go/exp/services/soroban-rpc@$SOROBAN_RPC_VERSION
 
 FROM ubuntu:20.04
 
@@ -32,7 +33,7 @@ ADD install /
 RUN ["chmod", "+x", "install"]
 RUN /install
 COPY --from=go /go/bin/friendbot /usr/local/bin/friendbot
-COPY --from=go /go/bin/soroban-rpc /usr/local/bin/soroban-rpc
+#COPY --from=go /go/bin/soroban-rpc /usr/local/bin/soroban-rpc
 
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,12 @@
 ARG STELLAR_CORE_IMAGE_REF
 ARG HORIZON_IMAGE_REF
 ARG FRIENDBOT_IMAGE_REF
+ARG SOROBAN_RPC_IMAGE_REF
 
 FROM $STELLAR_CORE_IMAGE_REF AS stellar-core
 FROM $HORIZON_IMAGE_REF AS horizon
 FROM $FRIENDBOT_IMAGE_REF AS friendbot
+FROM $SOROBAN_RPC_IMAGE_REF AS soroban-rpc
 
 FROM ubuntu:20.04
 
@@ -24,6 +26,8 @@ COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
 
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
+
+COPY --from=soroban-rpc /app/soroban-rpc /usr/local/bin/soroban-rpc
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -9,7 +9,7 @@ ARG FRIENDBOT_VERSION
 ARG SOROBAN_RPC_VERSION
 
 RUN go install github.com/stellar/go/services/friendbot@$FRIENDBOT_VERSION
-RUN go install github.com/stellar/go/exp/services/soroban-rpc$SOROBAN_RPC_VERSION
+RUN go install github.com/stellar/go/exp/services/soroban-rpc@$SOROBAN_RPC_VERSION
 
 FROM ubuntu:20.04
 

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,12 +1,15 @@
 ARG STELLAR_CORE_VERSION=19.3.0-1006.9ce6dc4e9.focal
 ARG HORIZON_VERSION=2.20.0-296
 ARG FRIENDBOT_VERSION=horizon-v2.20.0
+ARG SOROBAN_RPC_VERSION=horizon-v2.20.0
 
 FROM golang:1.19 as go
 
 ARG FRIENDBOT_VERSION
+ARG SOROBAN_RPC_VERSION
 
 RUN go install github.com/stellar/go/services/friendbot@$FRIENDBOT_VERSION
+RUN go install github.com/stellar/go/exp/services/soroban-rpc$SOROBAN_RPC_VERSION
 
 FROM ubuntu:20.04
 
@@ -29,6 +32,7 @@ ADD install /
 RUN ["chmod", "+x", "install"]
 RUN /install
 COPY --from=go /go/bin/friendbot /usr/local/bin/friendbot
+COPY --from=go /go/bin/soroban-rpc /usr/local/bin/soroban-rpc
 
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 __PHONY__: build build-testing build-dev build-dev-deps
 
+GO_REPO_BRANCH=master	
+
 build:
 	docker build --platform linux/amd64 -t stellar/quickstart -f Dockerfile .
 
@@ -7,9 +9,10 @@ build-testing:
 	docker build --platform linux/amd64 -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-dev-deps:
-	docker build -t stellar-core:master -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
-	docker build -t stellar-horizon:master -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#master
-	docker build -t stellar-friendbot:master -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#master
+	docker build --platform linux/amd64 -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#master --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build --platform linux/amd64 -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
+	docker build --platform linux/amd64 -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
+	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f exp/services/soroban-rpc/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 
 build-dev: build-dev-deps
-	docker build -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:master --build-arg HORIZON_IMAGE_REF=stellar-horizon:master --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:master
+	docker build --platform linux/amd64 -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:dev --build-arg HORIZON_IMAGE_REF=stellar-horizon:dev --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:dev --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:dev

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ In order to get started quickly, you can deploy the docker image to a DigitalOce
 
 *Disclaimer*: The DigitalOcean server is publicly accessible on the Internet. Do not put sensitive information on the network that you would not want someone else to know. Anyone with access to the network will be able to use the root account above.
 
-### Enable Optional Soroban RPC server
+### Early Access, enable optional soroban RPC server
 
-You can run an instance of Soroban RPC server in the container also. At present the Soroban RPC server can only be enabled when using standalone network `--standalone`. Add the following command line flags to the `docker run` container invocation to enable Soroban RPC server to be launched:
+You can run an instance of soroban rpc server in the container also. At present the Soroban RPC server is in early phases of development and can only be enabled when using standalone network `--standalone` and should only be used in a learning or development purpose for now, do not enable it for production environments. 
+Add the following command line flags to the `docker run` container invocation to enable Soroban RPC server to be launched:
 `--enable-horizon-captive-core --enable-soroban-rpc`
 
 You will then be able to connect to the Soroban RPC Server on port 8000 of the container, the root url path for Soroban RPC is `http://<container_host>:8000/soroban/rpc`. This endpoint uses [JSON-RPC](https://www.jsonrpc.org/specification) protocol, and also refer to example usages in [soroban-example-dapp](https://github.com/stellar/soroban-example-dapp) 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The image uses the following software:
 - Postgresql 12 is used for storing both stellar-core and horizon data
 - [stellar-core](https://github.com/stellar/stellar-core)
 - [horizon](https://github.com/stellar/go/tree/master/services/horizon)
+- [soroban-rpc](https://github.com/stellar/go/tree/master/exp/services/soroban-rpc)
 - Supervisord is used from managing the processes of the services above
 
 ## Usage
@@ -63,6 +64,13 @@ In order to get started quickly, you can deploy the docker image to a DigitalOce
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/stellar/docker-stellar-core-horizon/tree/master)
 
 *Disclaimer*: The DigitalOcean server is publicly accessible on the Internet. Do not put sensitive information on the network that you would not want someone else to know. Anyone with access to the network will be able to use the root account above.
+
+### Enable Optional Soroban RPC server
+
+You can run an instance of Soroban RPC server in the container also. At present the Soroban RPC server can only be enabled when using standalone network `--standalone`. Add the following command line flags to the `docker run` container invocation to enable Soroban RPC server to be launched:
+`--enable-horizon-captive-core --enable-soroban-rpc`
+
+You will then be able to connect to the Soroban RPC Server on port 8000 of the container, the root url path for Soroban RPC is `http://<container_host>:8000/soroban/rpc`. This endpoint uses [JSON-RPC](https://www.jsonrpc.org/specification) protocol, and also refer to example usages in [soroban-example-dapp](https://github.com/stellar/soroban-example-dapp) 
 
 ### Background vs. Interactive containers
 

--- a/common/nginx/etc/nginx.conf
+++ b/common/nginx/etc/nginx.conf
@@ -16,6 +16,12 @@ http {
                         proxy_pass http://127.0.0.1:8001;
                 }
 
+                location /soroban/rpc {
+                        rewrite /soroban/rpc / break;
+                        proxy_pass http://127.0.0.1:8003;
+                        proxy_redirect off;
+                } 
+
                 location @502 {
                         return 502 "502 Bad Gateway";
                 }

--- a/common/soroban-rpc/bin/start
+++ b/common/soroban-rpc/bin/start
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -e
+set -o pipefail
+
+while ! (curl -sf http://localhost:8001/ | jq --exit-status '.current_protocol_version > 0'); do
+  echo "Waiting for horizon to be available..."
+  sleep 1
+done
+
+echo "starting soroban-rpc..."
+source /opt/stellar/soroban-rpc/etc/soroban-rpc.env
+exec /usr/local/bin/soroban-rpc

--- a/common/soroban-rpc/etc/soroban-rpc.env
+++ b/common/soroban-rpc/etc/soroban-rpc.env
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export PORT=8003
+export HORIZON_URL=http://localhost:8001

--- a/common/supervisor/etc/supervisord.conf.d/soroban-rpc.conf
+++ b/common/supervisor/etc/supervisord.conf.d/soroban-rpc.conf
@@ -1,0 +1,8 @@
+[program:soroban-rpc]
+user=stellar
+directory=/opt/stellar/soroban-rpc
+command=/opt/stellar/soroban-rpc/bin/start
+autostart=true
+autorestart=true
+priority=60
+redirect_stderr=true

--- a/standalone/nginx/etc/nginx.conf
+++ b/standalone/nginx/etc/nginx.conf
@@ -22,6 +22,12 @@ http {
                         proxy_pass http://127.0.0.1:8001;
                 }
 
+                location /soroban/rpc {
+                        rewrite /soroban/rpc / break;
+                        proxy_pass http://127.0.0.1:8003;
+                        proxy_redirect off;
+                } 
+
                 location @502 {
                         return 502 "502 Bad Gateway";
                 }

--- a/standalone/supervisor/etc/supervisord.conf.d/friendbot.conf
+++ b/standalone/supervisor/etc/supervisord.conf.d/friendbot.conf
@@ -4,5 +4,6 @@ directory=/opt/stellar/friendbot
 command=/opt/stellar/friendbot/bin/start
 autostart=true
 autorestart=true
+startretries=100
 priority=40
 redirect_stderr=true

--- a/start
+++ b/start
@@ -8,6 +8,7 @@ export COREHOME="$STELLAR_HOME/core"
 export HZHOME="$STELLAR_HOME/horizon"
 export FBHOME="$STELLAR_HOME/friendbot"
 export NXHOME="$STELLAR_HOME/nginx"
+export SOROBAN_RPC_HOME="$STELLAR_HOME/soroban-rpc"
 
 export PGBIN="/usr/lib/postgresql/12/bin/"
 export PGDATA="$PGHOME/data"
@@ -15,6 +16,7 @@ export PGUSER="stellar"
 export PGPORT=5432
 
 ENABLE_HORIZON_CAPTIVE_CORE=false
+ENABLE_SOROBAN_RPC=false
 ENABLE_CORE_MANUAL_CLOSE=false
 ENABLE_CORE_ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING=false
 
@@ -29,6 +31,10 @@ function main() {
   process_args $*
   if [ "$NETWORK" != "standalone" ] && [ "$ENABLE_HORIZON_CAPTIVE_CORE" = "true" ]; then
     echo "--enable-horizon-captive-core is only supported in the standalone network" >&2
+    exit 1
+  fi
+  if [ "$NETWORK" != "standalone" ] && [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
+    echo "--enable-soroban-rpc is only supported in the standalone network" >&2
     exit 1
   fi
   if [ "$NETWORK" != "standalone" ] && [ "$ENABLE_CORE_ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING" = "true" ]; then
@@ -86,6 +92,9 @@ function process_args() {
     --enable-horizon-captive-core)
       ENABLE_HORIZON_CAPTIVE_CORE=true
       ;;
+    --enable-soroban-rpc)
+      ENABLE_SOROBAN_RPC=true
+      ;;  
     --enable-core-manual-close)
       ENABLE_CORE_MANUAL_CLOSE=true
       ;;
@@ -206,6 +215,15 @@ function copy_defaults() {
     echo "horizon: config directory exists, skipping copy"
   else
     $CP /opt/stellar-default/common/horizon/ $HZHOME
+  fi
+
+  if [ -d $SOROBAN_RPC_HOME/etc ]; then
+    echo "horizon: config directory exists, skipping copy"
+  elif [  "$ENABLE_SOROBAN_RPC" = "true" ]; then
+    $CP /opt/stellar-default/common/soroban-rpc/ $SOROBAN_RPC_HOME
+    if [ -d /opt/stellar-default/$NETWORK/soroban-rpc/ ]; then
+      $CP /opt/stellar-default/$NETWORK/soroban-rpc/ $SOROBAN_RPC_HOME
+    fi
   fi
 
   if [ -d $FBHOME/etc ]; then

--- a/start
+++ b/start
@@ -218,7 +218,7 @@ function copy_defaults() {
   fi
 
   if [ -d $SOROBAN_RPC_HOME/etc ]; then
-    echo "horizon: config directory exists, skipping copy"
+    echo "soroban-rpc: config directory exists, skipping copy"
   elif [  "$ENABLE_SOROBAN_RPC" = "true" ]; then
     $CP /opt/stellar-default/common/soroban-rpc/ $SOROBAN_RPC_HOME
     if [ -d /opt/stellar-default/$NETWORK/soroban-rpc/ ]; then

--- a/test_soroban_rpc_up.go
+++ b/test_soroban_rpc_up.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const timeout = 3 * time.Minute
+
+type Root struct {
+	Status string `json:"status"`
+}
+
+func main() {
+	startTime := time.Now()
+
+	for {
+		time.Sleep(5 * time.Second)
+		logLine("Waiting for Soroban RPC to start")
+
+		if time.Since(startTime) > timeout {
+			logLine("Timeout")
+			os.Exit(-1)
+		}
+
+		resp, err := http.Get("http://localhost:8000/soroban/rpc/getHealth")
+		if err != nil {
+			logLine(err)
+			continue
+		}
+
+		var root Root
+		decoder := json.NewDecoder(resp.Body)
+		err = decoder.Decode(&root)
+		if err != nil {
+			logLine(err)
+			continue
+		}
+
+		if root.Status == "healthy" {
+			logLine("Soroban RPC has started!")
+			os.Exit(0)
+		}
+	}
+}
+
+func logLine(text interface{}) {
+	log.Println("\033[32;1m[test]\033[0m", text)
+}

--- a/test_soroban_rpc_up.go
+++ b/test_soroban_rpc_up.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -10,12 +11,18 @@ import (
 
 const timeout = 3 * time.Minute
 
-type Root struct {
+type RPCResponse struct {
 	Status string `json:"status"`
 }
 
 func main() {
 	startTime := time.Now()
+
+    getHealthRPCRequest := []byte(`{
+    	   "jsonrpc": "2.0",
+    	   "id": 10235,
+    	   "method": "getHealth"
+    	}`)
 
 	for {
 		time.Sleep(5 * time.Second)
@@ -26,21 +33,21 @@ func main() {
 			os.Exit(-1)
 		}
 
-		resp, err := http.Get("http://localhost:8000/soroban/rpc/getHealth")
+		resp, err := http.Post("http://localhost:8000/soroban/rpc", "application/json",bytes.NewBuffer(getHealthRPCRequest))
 		if err != nil {
 			logLine(err)
 			continue
 		}
 
-		var root Root
+		var rpcResponse RPCResponse
 		decoder := json.NewDecoder(resp.Body)
-		err = decoder.Decode(&root)
+		err = decoder.Decode(&rpcResponse)
 		if err != nil {
 			logLine(err)
 			continue
 		}
 
-		if root.Status == "healthy" {
+		if rpcResponse.Status == "healthy" {
 			logLine("Soroban RPC has started!")
 			os.Exit(0)
 		}

--- a/test_soroban_rpc_up.go
+++ b/test_soroban_rpc_up.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -11,14 +12,18 @@ import (
 
 const timeout = 3 * time.Minute
 
-type RPCResponse struct {
+type RPCResult struct {
 	Status string `json:"status"`
+}
+
+type RPCResponse struct {
+	Result RPCResult `json:"result"`
 }
 
 func main() {
 	startTime := time.Now()
 
-    getHealthRPCRequest := []byte(`{
+	getHealthRPCRequest := []byte(`{
     	   "jsonrpc": "2.0",
     	   "id": 10235,
     	   "method": "getHealth"
@@ -33,7 +38,7 @@ func main() {
 			os.Exit(-1)
 		}
 
-		resp, err := http.Post("http://localhost:8000/soroban/rpc", "application/json",bytes.NewBuffer(getHealthRPCRequest))
+		resp, err := http.Post("http://localhost:8000/soroban/rpc", "application/json", bytes.NewBuffer(getHealthRPCRequest))
 		if err != nil {
 			logLine(err)
 			continue
@@ -47,7 +52,9 @@ func main() {
 			continue
 		}
 
-		if rpcResponse.Status == "healthy" {
+		logLine(fmt.Sprintf("Soroban RPC health reponse %v", rpcResponse))
+
+		if rpcResponse.Result.Status == "healthy" {
 			logLine("Soroban RPC has started!")
 			os.Exit(0)
 		}


### PR DESCRIPTION
Initial rough changes made on the image to confirm a spike that soroban-rpc will work in the image container runtime without conflict at same time that horizon is running with captive core and be able to use Horizon's API endpoints.

soroban-rpc is not launching it's own captive-core or doing any ingesting, instead it is just connecting to the horizon API HTTP service per latest changes related to getAccount on [#4556](https://github.com/stellar/go/issues/4556) by @tamirms.

I've done live testing on this branch to confirm behavior:
```
$ make build-dev GO_REPO_BRANCH=pull/4591/head
$ docker run --platform linux/amd64 --rm -it -p "8000:8000" --name stellar stellar/quickstart:dev --standalone --enable-soroban-rpc --enable-horizon-captive-core
``` 

after startup, have to wait for first 63 ledgers to be generated on standalone first, then horizon's ingestion gets caught up, and it then will serve api requests, the soroban-rpc service can be accessed through the nginx proxy provided by quickstart's 8000 port:
`http://localhost:8000/soroban/rpc`

soroban-rpc is JSON-RPC protocol, so HTTP requests have be POSTs, such as:

```
{
  "jsonrpc": "2.0",
  "id": 10235,
  "method": "getHealth" 
}
```

or 

```
{
  "jsonrpc": "2.0",
  "id": 10235,
  "method": "getAccount",
  "params": { 
      "address": "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI"
  }
}
```

Closes https://github.com/stellar/go/issues/4590 
