### PR TITLE
Add complete CI job that we can make a required check

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -23,6 +23,13 @@ env:
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-dev', github.event.pull_request.number) || 'dev') }}
 
 jobs:
+  complete:
+    if: always()
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
 
   build-stellar-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/Dockerfile.testing.yml
+++ b/.github/workflows/Dockerfile.testing.yml
@@ -19,6 +19,13 @@ env:
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-testing', github.event.pull_request.number) || 'testing') }}
 
 jobs:
+  complete:
+    if: always()
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Dockerfile.yml
+++ b/.github/workflows/Dockerfile.yml
@@ -19,6 +19,14 @@ env:
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'latest') }}
 
 jobs:
+  complete:
+    if: always()
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What
Add complete CI job that we can make a required check instead of requiring individual jobs.

### Why
This is the pattern we use on newer repositories and this brings this repository up-to-date.

Having a single CI job that is a required check moves the definition of what is required down to the repo and out of the GitHub settings. This has a couple advantages:
- It is easier to express dependencies inside the GitHub Actions YAML files. We can say that all builds are required, or all tests, and it is a single word that will require all instances of a matrix. It is harder to express the same in GitHub required check configurations because each individual matrix instance has to be listed separately.
- Developers can control what builds are required by editing repo code, rather than getting an administrator to change GitHub configurations.

An example of where we already use this pattern is: https://github.com/stellar/go/blob/5585714a6102f5cd0273df853ea8a47c1c6bfddb/.github/workflows/go.yml#L9-L15