### PR TITLE
wait loop for horizon based on ingest ledger number

### DIFF
--- a/common/friendbot/bin/start
+++ b/common/friendbot/bin/start
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-while ! (curl -sf http://localhost:8001/ | jq --exit-status '.current_protocol_version > 0'); do
+while ! (curl -sf http://localhost:8001/ | jq --exit-status '.ingest_latest_ledger > 1'); do
   echo "Waiting for horizon to be available..."
   sleep 1
 done

--- a/common/soroban-rpc/bin/start
+++ b/common/soroban-rpc/bin/start
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-while ! (curl -sf http://localhost:8001/ | jq --exit-status '.current_protocol_version > 0'); do
+while ! (curl -sf http://localhost:8001/ | jq --exit-status '.ingest_latest_ledger > 1'); do
   echo "Waiting for horizon to be available..."
   sleep 1
 done


### PR DESCRIPTION
check horizon ingestion ledger count from supervisor startup to determine when horizon service is truly available, friendbot and soroban-rpc use the same mechanism of to wait on horizon their respective log files in `/var/log/supervisor/` will show their looping attempts to check horizon state. this is more pronounced wait time when `--enable-horizon-captive-core` is used. 

i tested with:
```
$ make build-dev
$ docker run --platform linux/amd64 --rm -it -p 8000:8000 --name stellar stellar/quickstart:dev --standalone --enable-horizon-captive-core --enable-soroban-rpc