### PR TITLE
nginx, fix host/port forwarding

### DIFF
--- a/Dockerfile.soroban-dev
+++ b/Dockerfile.soroban-dev
@@ -1,7 +1,7 @@
 ARG STELLAR_CORE_VERSION=19.4.1-1097.4e813f20e.focal~soroban
 ARG HORIZON_VERSION=2.22.0~soroban-304
 ARG FRIENDBOT_VERSION=soroban-xdr-next
-ARG SOROBAN_RPC_VERSION=soroban-xdr-next
+ARG SOROBAN_RPC_VERSION=soroban-rpc-v0.0.1-alpha
 
 FROM golang:1.19 as go
 

--- a/Dockerfile.soroban-dev
+++ b/Dockerfile.soroban-dev
@@ -1,6 +1,6 @@
 ARG STELLAR_CORE_VERSION=19.4.1-1097.4e813f20e.focal~soroban
 ARG HORIZON_VERSION=2.22.0~soroban-304
-ARG FRIENDBOT_VERSION=soroban-xdr-next
+ARG FRIENDBOT_VERSION=soroban-rpc-v0.0.1-alpha
 ARG SOROBAN_RPC_VERSION=soroban-rpc-v0.0.1-alpha
 
 FROM golang:1.19 as go

--- a/common/nginx/etc/nginx.conf
+++ b/common/nginx/etc/nginx.conf
@@ -19,11 +19,13 @@ http {
                 }
 
                 location / {
+                        proxy_set_header Host $host;
                         proxy_pass http://127.0.0.1:8001;
                 }
 
                 location /soroban/rpc {
                         rewrite /soroban/rpc / break;
+                        proxy_set_header Host $host;
                         proxy_pass http://127.0.0.1:8003;
                         proxy_redirect off;
                 } 

--- a/common/nginx/etc/nginx.conf
+++ b/common/nginx/etc/nginx.conf
@@ -19,13 +19,13 @@ http {
                 }
 
                 location / {
-                        proxy_set_header Host $host;
+                        proxy_set_header Host $host:$server_port;
                         proxy_pass http://127.0.0.1:8001;
                 }
 
                 location /soroban/rpc {
                         rewrite /soroban/rpc / break;
-                        proxy_set_header Host $host;
+                        proxy_set_header Host $host:$server_port;
                         proxy_pass http://127.0.0.1:8003;
                         proxy_redirect off;
                 } 


### PR DESCRIPTION
Noticed that from the nginx localhost:8000 on quickstart, when accessing horizon, the horizon HAL links were being written with the local back-end host:port info instead of nginx proxy host:port:

```
"_links": {
    "account": {
      "href": "http://127.0.0.1:8001/accounts/{account_id}",
      "templated": true
    },
....

```

this changes proxy to forward proxyhost:proxyport to backing services instead.

Also, created a tag to refer to soroban rpc source version to be used during docker build - [soroban-rpc-v0.0.1-alpha](https://github.com/stellar/go/releases/tag/soroban-rpc-v0.0.1-alpha)