### PR TITLE
remove random passphrase flag from digitalocean button

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -6,4 +6,4 @@ spec:
       branch: master
       repo_clone_url: https://github.com/stellar/docker-stellar-core-horizon.git
     name: docker-stellar-core-horizon
-    run_command: /start --standalone --randomize-network-passphrase
+    run_command: /start --standalone


### PR DESCRIPTION
removing random passphrase flag from digitalocean button start command

causing an error with friendbot when the container starts, see more [on slack](https://stellarfoundation.slack.com/archives/C030Z9EHVQE/p1668543220518399?thread_ts=1666107837.290549&cid=C030Z9EHVQE)