### PR TITLE
quickstart: update soroban-rpc repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 __PHONY__: build build-testing build-dev build-dev-deps
 
 GO_REPO_BRANCH=master	
-CORE_REPO_BRANCH=master	
+CORE_REPO_BRANCH=master
+SOROBAN_TOOLS_REPO_BRANCH=main
 
 build:
 	docker build --platform linux/amd64 -t stellar/quickstart -f Dockerfile .
@@ -16,7 +17,7 @@ build-dev-deps:
 	docker build --platform linux/amd64 -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REPO_BRANCH) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 	docker build --platform linux/amd64 -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 	docker build --platform linux/amd64 -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
-	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f exp/services/soroban-rpc/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
+	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
 
 build-dev: build-dev-deps
 	docker build --platform linux/amd64 -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:dev --build-arg HORIZON_IMAGE_REF=stellar-horizon:dev --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:dev --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:dev

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image uses the following software:
 - [stellar-core](https://github.com/stellar/stellar-core)
 - [horizon](https://github.com/stellar/go/tree/master/services/horizon)
 - [friendbot](https://github.com/stellar/go/tree/master/services/friendbot)
-- [soroban-rpc](https://github.com/stellar/go/tree/master/exp/services/soroban-rpc)
+- [soroban-rpc](https://github.com/stellar/soroban-tools/tree/main/cmd/soroban-rpc)
 - Supervisord is used from managing the processes of the services above
 
 ## Usage


### PR DESCRIPTION
## What ?

Update the quickstart image building to use the updated soroban-rpc from the soroban-tools repository.

## Notes

The current makefile takes the soroban rpc and the horizon from their master/main branches. That is wrong and need to be addressed ( in a future PR )