### PR TITLE
Build Dockerfile.dev with host platform on last futurenet release commits

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,7 @@ COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
 
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
 
-COPY --from=soroban-rpc /app/soroban-rpc /usr/bin/stellar-soroban-rpc
+COPY --from=soroban-rpc /bin/soroban-rpc /usr/bin/stellar-soroban-rpc
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-dev-deps-friendbot:
 	docker build --platform linux/amd64 -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 
 build-dev-deps-soroban-rpc:
-	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
+	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
 
 # the build-dev-deps have the four dependencies for the building of the
 # dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 __PHONY__: build build-testing build-dev build-dev-deps
 
-CORE_REPO_BRANCH=master
-SOROBAN_TOOLS_REPO_BRANCH=main
+CORE_REPO_BRANCH=49562bd9a91f4bbf572f7ded90f54fa9d91f8957 # futurenet is b3a6bc28116e80bff7889c2f3bcd7c30dd1ac4d6
+SOROBAN_TOOLS_REPO_BRANCH=46e72d89f5201ecd67c729dd9f29b59df991d9aa
 GO_REPO_BRANCH := $(shell ./scripts/soroban_repo_to_horizon_repo.sh $(SOROBAN_TOOLS_REPO_BRANCH))
 
 build:
@@ -14,7 +14,7 @@ build-soroban-dev:
 	docker build --no-cache -t stellar/quickstart:soroban-dev -f Dockerfile.soroban-dev .
 
 build-dev-deps-core:
-	docker build -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REPO_BRANCH) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/leighmcculloch/stellar--stellar-core.git#$(CORE_REPO_BRANCH) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests --enable-next-protocol-version-unsafe-for-production'
 
 build-dev-deps-horizon:
 	docker build -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#$(GO_REPO_BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,19 @@ build-testing:
 	docker build --platform linux/amd64 -t stellar/quickstart:testing -f Dockerfile.testing .
 
 build-soroban-dev:
-	docker build --platform linux/amd64 --no-cache -t stellar/quickstart:soroban-dev -f Dockerfile.soroban-dev .
+	docker build --no-cache -t stellar/quickstart:soroban-dev -f Dockerfile.soroban-dev .
 
 build-dev-deps-core:
-	docker build --platform linux/amd64 -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REPO_BRANCH) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
+	docker build -t stellar-core:dev -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REPO_BRANCH) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CFLAGS='' --build-arg CXXFLAGS='-stdlib=libc++' --build-arg CONFIGURE_FLAGS='--disable-tests'
 
 build-dev-deps-horizon:
-	docker build --platform linux/amd64 -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
+	docker build -t stellar-horizon:dev -f services/horizon/docker/Dockerfile.dev --target builder https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 
 build-dev-deps-friendbot:
-	docker build --platform linux/amd64 -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
+	docker build -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 
 build-dev-deps-soroban-rpc:
-	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
+	docker build -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
 
 # the build-dev-deps have the four dependencies for the building of the
 # dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies
@@ -31,4 +31,4 @@ build-dev-deps-soroban-rpc:
 build-dev-deps: build-dev-deps-core build-dev-deps-horizon build-dev-deps-friendbot build-dev-deps-soroban-rpc
 
 build-dev: build-dev-deps
-	docker build --platform linux/amd64 -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:dev --build-arg HORIZON_IMAGE_REF=stellar-horizon:dev --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:dev --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:dev
+	docker build -t stellar/quickstart:dev -f Dockerfile.dev . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:dev --build-arg HORIZON_IMAGE_REF=stellar-horizon:dev --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:dev --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:dev


### PR DESCRIPTION
### What
Build Dockerfile.dev with host platform on last futurenet release commits.

### Why
To see if we can get an arm64 image.