### PR TITLE
Fix soroban-rpc in Dockerfile.dev

### DIFF
--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -22,6 +22,7 @@ env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-dev', github.event.pull_request.number) || 'dev') }}
   GO_REPO_BRANCH: master
+  SOROBAN_TOOLS_REPO_BRANCH: main
   CORE_REPO_BRANCH: master
 
 jobs:
@@ -74,7 +75,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Soraban-Rpc Image
-      run: docker buildx build -f exp/services/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#${{ env.GO_REPO_BRANCH }}
+      run: docker buildx build -f cmd/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc -o type=docker,dest=/tmp/image https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/Dockerfile.dev.yml
+++ b/.github/workflows/Dockerfile.dev.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
     - uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Soraban-Rpc Image
-      run: docker buildx build -f exp/services/soroban-rpc/docker/Dockerfile -t stellar-soroban-rpc -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#${{ env.GO_REPO_BRANCH }}
+      run: docker buildx build -f exp/services/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc -o type=docker,dest=/tmp/image https://github.com/stellar/go.git#${{ env.GO_REPO_BRANCH }}
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -27,7 +27,7 @@ COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
 
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
 
-COPY --from=soroban-rpc /app/soroban-rpc /usr/bin/stellar-soroban-rpc
+COPY --from=soroban-rpc /bin/soroban-rpc /usr/bin/stellar-soroban-rpc
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-dev-deps-friendbot:
 	docker build --platform linux/amd64 -t stellar-friendbot:dev -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REPO_BRANCH)
 
 build-dev-deps-soroban-rpc:
-	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
+	docker build --platform linux/amd64 -t stellar-soroban-rpc:dev -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REPO_BRANCH)
 
 # the build-dev-deps have the four dependencies for the building of the
 # dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies


### PR DESCRIPTION
### What
Correct the path of where to find the soroban-rpc binary in the soroban-rpc image used for building. When building the soroban-rpc only build the `build` target.

### Why
The binary is in a different location in this image and it looks like we're using the wrong location.

The `--target build` is required to only build the soroban-rpc itself, and not build the rest of the image which has a dependency on stellar-core.