### PR TITLE
Fix name of images when released from master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-', github.event.pull_request.number)) }}${{ inputs.tag }}
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
   GO_REPO_BRANCH: ${{ inputs.go_ref }}
   SOROBAN_TOOLS_REPO_BRANCH: ${{ inputs.soroban_tools_ref }}
   CORE_REPO_BRANCH: ${{ inputs.core_ref }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-', github.event.pull_request.number)) }}${{ inputs.tag }}
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr-{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
   REGISTRY: ${{ secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io' }}
 
 jobs:


### PR DESCRIPTION
### What
Remove the prefix "false" from the names of images when released from master.

### Why
I changed how the image name was generated in #397 and accidentally introduced the word "false" into the prefix when the image is built not from a pull request. This change reverts the change to the image name.

<img width="373" alt="Screenshot 2023-01-13 at 2 15 59 PM" src="https://user-images.githubusercontent.com/351529/212429767-dc6356fd-9261-4173-b0bc-87e3939096dc.png">
