### PR TITLE
Pass through host from http request to horizon and soroban-rpc

### DIFF
--- a/common/nginx/etc/nginx.conf
+++ b/common/nginx/etc/nginx.conf
@@ -19,13 +19,13 @@ http {
                 }
 
                 location / {
-                        proxy_set_header Host $host:$server_port;
+                        proxy_set_header Host $http_host;
                         proxy_pass http://127.0.0.1:8001;
                 }
 
                 location /soroban/rpc {
                         rewrite /soroban/rpc / break;
-                        proxy_set_header Host $host:$server_port;
+                        proxy_set_header Host $http_host;
                         proxy_pass http://127.0.0.1:8003;
                         proxy_redirect off;
                 } 


### PR DESCRIPTION
### What
Pass through host from http request to horizon and soroban-rpc.

### Impact
This results in whatever is in the HTTP request Host header to be echoed back in responses in the `_links` field.

For example:

Request:
```http
GET / HTTP/1.1
Accept-Encoding: gzip
Host: example.com
User-Agent: httpie-go/0.7.0
```

Response:
```http
HTTP/1.1 200 OK
Cache-Control: no-cache, no-store, max-age=0
Connection: keep-alive
Content-Disposition: inline
Content-Type: application/hal+json; charset=utf-8
Date: Thu, 19 Jan 2023 00:39:00 GMT
Server: nginx/1.18.0 (Ubuntu)
Vary: Accept-Encoding
X-Ratelimit-Limit: 101
X-Ratelimit-Remaining: 100
X-Ratelimit-Reset: 1

{
    "_links": {
        "account": {
            "href": "http://example.com/accounts/{account_id}",
            "templated": true
        },
```

### Why
Horizon and Soroban-RPC included the host (hostname:port) in their http responses. We set the host header to the nginx hostname and nginx port so that when running the docker image Horizon and Soroban-RPC echo back the nginx hostname and port (8000) instead of the services internal port (8001 and 8003 respectively).

The problem with this is that most of the time when running a docker container port mappings change what port the user is seeing the service on. While nginx is on port 8000, there's a good chance a deployment is mapping port 80 to port 8000, and then nginx is mapping port 8000 to port 8001 for Horizon.

Horizon needs to know about the deployed hostname and port to use in its API responses that include a fully qualified URL.

This PR takes the approach of using the HTTP request's Host header for this purpose, since it is the top-level user facing value, we know it is the value that the user will expect to use for accessing other URLs on the server.

Doing so is potentially riskier in that it exposts the quickstart image to a host header injection attack vector where someone could front the quickstart image with a host name unintended by the operator, and the image's API responses will return fully qualified URLs with that other domain. It is however unlikely that this could be used in a meaningful way since the host header is not used by Horizon in any meaningful way other than in the return responses for other endpoints that are available relating to the acccessed resource. Since this can only occur when a system is already using the wrong URL, it seems unlikely to be a problem for the Horizon server to return a response to a system already using the wrong domain.

The safest thing to do here is to add an environment variable to Horizon where you can configure what the fully qualified host name is, and it'd use that. Since it relies on no user information it isn't vulnerable to any sort of injection attack. However, adding an environment variable to be configured in this way isn't necessarily easy to configure in all environments. Some environments determine the host name after deployment, not ahead of time.

