### PR TITLE
Emit stdout status of stellar-core

### DIFF
--- a/start
+++ b/start
@@ -501,10 +501,23 @@ popd() {
 }
 
 function service_status() {
+  stellar_core_status &
   horizon_status
   if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
     soroban_rpc_status
   fi
+}
+
+function stellar_core_status() {
+  local last_status=""
+  while true; do
+    local status="$(curl --silent --location 'http://localhost:11626/info' | jq -r '"\([.info.state] + (.info.status // []) | join("; "))"')"
+    if [ "$status" != "$last_status" ]; then
+      echo "stellar-core: $status"
+    fi
+    last_status="$status"
+    sleep 1
+  done
 }
 
 function soroban_rpc_status() {


### PR DESCRIPTION
### What
Emit logs to stdout containing the current state of stellar-core.

### Why
Whilst the stellar-core logs are available on the instance, it would be helpful, they're noisy, and somewhat advanced. Stellar-core has an endpoint that presents a rather friendly state of stellar-core. Multiple folks have expressed interest that being visible in the container logs. Stellar-core is the core component of the quickstart image. Everything hinges on its state, and whether it is caught up. While we probably shouldn't put state and logs like this for every application, stellar-core's state feels important enough that it could be outputted here. When folks connect to networks like futurenet or testnet and need to wait 5 minutes to join the network, this gives them clear feedback that nothing is wrong and they just need to wait.

Close #394
Close #407

### Merging

This pull request is intended to be merged to `master` after #409.

### Example

This is an example of the logs running with the `--futurenet` option.

```
Starting Stellar Quickstart

mode: ephemeral
network: futurenet (Test SDF Future Network ; October 2022)
postgres user: stellar
postgres password: ...
finalize-pgpass: ok
init-postgres: ok
postgres: up
create-horizon-db: ok
create-core-db: ok
stellar-postgres-user: ok
chown-core: ok
finalize-core-config-pgpass: ok
finalize-core-config-run-standalone: ok
finalize-core-config-artificially-accelerate-time-for-testing: ok
finalize-core-config-manual-close: ok
init-core-db: ok
chown-horizon: ok
init-horizon-db: ok
postgres: down
starting supervisor...
horizon: waiting for ingestion to catch up...
2023-01-25 04:32:33,622 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2023-01-25 04:32:33,622 INFO Included extra file "/opt/stellar/supervisor/etc/supervisord.conf.d/horizon.conf" during parsing
2023-01-25 04:32:33,622 INFO Included extra file "/opt/stellar/supervisor/etc/supervisord.conf.d/nginx.conf" during parsing
2023-01-25 04:32:33,622 INFO Included extra file "/opt/stellar/supervisor/etc/supervisord.conf.d/postgresql.conf" during parsing
2023-01-25 04:32:33,622 INFO Included extra file "/opt/stellar/supervisor/etc/supervisord.conf.d/stellar-core.conf" during parsing
2023-01-25 04:32:33,627 INFO RPC interface 'supervisor' initialized
2023-01-25 04:32:33,628 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2023-01-25 04:32:33,628 INFO supervisord started with pid 1
2023-01-25 04:32:34,630 INFO spawned: 'postgresql' with pid 172
2023-01-25 04:32:34,631 INFO spawned: 'stellar-core' with pid 173
2023-01-25 04:32:34,632 INFO spawned: 'horizon' with pid 174
2023-01-25 04:32:34,633 INFO spawned: 'nginx' with pid 175
2023-01-25 04:32:34,633 INFO reaped unknown pid 151
stellar-core: Joining SCP
2023-01-25 04:32:35,918 INFO success: postgresql entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2023-01-25 04:32:35,918 INFO success: stellar-core entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2023-01-25 04:32:35,918 INFO success: horizon entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2023-01-25 04:32:35,918 INFO success: nginx entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
stellar-core: Catching up; Waiting for trigger ledger: 253073/253121, ETA: 240s
stellar-core: Catching up; Waiting for trigger ledger: 253074/253121, ETA: 235s
stellar-core: Catching up; Waiting for trigger ledger: 253075/253121, ETA: 230s
stellar-core: Catching up; Waiting for trigger ledger: 253076/253121, ETA: 225s
stellar-core: Catching up; Waiting for trigger ledger: 253077/253121, ETA: 220s
stellar-core: Catching up; Waiting for trigger ledger: 253078/253121, ETA: 215s
stellar-core: Catching up; Waiting for trigger ledger: 253079/253121, ETA: 210s
stellar-core: Catching up; Waiting for trigger ledger: 253080/253121, ETA: 205s
stellar-core: Catching up; Waiting for trigger ledger: 253081/253121, ETA: 200s
stellar-core: Catching up; Waiting for trigger ledger: 253082/253121, ETA: 195s
horizon: waiting for ingestion to catch up, 1 minutes...
stellar-core: Catching up; Waiting for trigger ledger: 253083/253121, ETA: 190s
stellar-core: Catching up; Waiting for trigger ledger: 253084/253121, ETA: 185s
stellar-core: Catching up; Waiting for trigger ledger: 253085/253121, ETA: 180s
stellar-core: Catching up; Waiting for trigger ledger: 253086/253121, ETA: 175s
stellar-core: Catching up; Waiting for trigger ledger: 253087/253121, ETA: 170s
stellar-core: Catching up; Waiting for trigger ledger: 253088/253121, ETA: 165s
stellar-core: Catching up; Waiting for trigger ledger: 253089/253121, ETA: 160s
stellar-core: Catching up; Waiting for trigger ledger: 253090/253121, ETA: 155s
stellar-core: Catching up; Waiting for trigger ledger: 253091/253121, ETA: 150s
stellar-core: Catching up; Waiting for trigger ledger: 253092/253121, ETA: 145s
stellar-core: Catching up; Waiting for trigger ledger: 253093/253121, ETA: 140s
stellar-core: Catching up; Waiting for trigger ledger: 253094/253121, ETA: 135s
horizon: waiting for ingestion to catch up, 2 minutes...
stellar-core: Catching up; Waiting for trigger ledger: 253095/253121, ETA: 130s
stellar-core: Catching up; Waiting for trigger ledger: 253096/253121, ETA: 125s
stellar-core: Catching up; Waiting for trigger ledger: 253097/253121, ETA: 120s
stellar-core: Catching up; Waiting for trigger ledger: 253098/253121, ETA: 115s
stellar-core: Catching up; Waiting for trigger ledger: 253099/253121, ETA: 110s
stellar-core: Catching up; Waiting for trigger ledger: 253100/253121, ETA: 105s
stellar-core: Catching up; Waiting for trigger ledger: 253101/253121, ETA: 100s
stellar-core: Catching up; Waiting for trigger ledger: 253102/253121, ETA: 95s
stellar-core: Catching up; Waiting for trigger ledger: 253103/253121, ETA: 90s
stellar-core: Catching up; Waiting for trigger ledger: 253104/253121, ETA: 85s
stellar-core: Catching up; Waiting for trigger ledger: 253105/253121, ETA: 80s
stellar-core: Catching up; Waiting for trigger ledger: 253106/253121, ETA: 75s
horizon: waiting for ingestion to catch up, 3 minutes...
stellar-core: Catching up; Waiting for trigger ledger: 253107/253121, ETA: 70s
stellar-core: Catching up; Waiting for trigger ledger: 253108/253121, ETA: 65s
stellar-core: Catching up; Waiting for trigger ledger: 253109/253121, ETA: 60s
stellar-core: Catching up; Waiting for trigger ledger: 253110/253121, ETA: 55s
stellar-core: Catching up; Waiting for trigger ledger: 253111/253121, ETA: 50s
stellar-core: Catching up; Waiting for trigger ledger: 253112/253121, ETA: 45s
stellar-core: Catching up; Waiting for trigger ledger: 253113/253121, ETA: 40s
stellar-core: Catching up; Waiting for trigger ledger: 253114/253121, ETA: 35s
stellar-core: Catching up; Waiting for trigger ledger: 253115/253121, ETA: 30s
stellar-core: Catching up; Waiting for trigger ledger: 253116/253121, ETA: 25s
stellar-core: Catching up; Waiting for trigger ledger: 253117/253121, ETA: 20s
horizon: waiting for ingestion to catch up, 4 minutes...
stellar-core: Catching up; Waiting for trigger ledger: 253118/253121, ETA: 15s
stellar-core: Catching up; Waiting for trigger ledger: 253119/253121, ETA: 10s
stellar-core: Catching up; Waiting for trigger ledger: 253120/253121, ETA: 5s
stellar-core: Catching up; Catching up to ledger 253119: downloading ledger files 3/3 (100%)
stellar-core: Catching up; Catching up to ledger 253119: Applying buffered ledgers: apply ledger 253121
stellar-core: Synced!
horizon: ingestion caught up
```