### PR TITLE
Silence the long user=root error supervisord outputs

### DIFF
--- a/common/supervisor/etc/supervisord.conf
+++ b/common/supervisor/etc/supervisord.conf
@@ -3,6 +3,7 @@ file=/var/run/supervisor.sock
 chmod=0700
 
 [supervisord]
+user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/supervisor


### PR DESCRIPTION
### What
Configure supervisord with `user=root`.

### Why
Supervisord assumes if it is running as root that the user has made a mistake and is accidentally running it as root. It prints out a long warning message that looks like this:
> 2023-01-25 06:01:34,140 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.

This log comes out in the container logs and is distracting. A user could think something is wrong. At best it takes up screen space for something that is okay and needs no action.

We run supervisord as root, and it's a common practice in Docker containers.

If we configure supervisord with a user, telling it which user we expect it to run as, and specify root, then supervisord assumes we know what we're doing and stops warning about it.