### PR TITLE
Add option for outputting service logs to container logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You can learn more about what commands are available by using the `help` command
 
 Logs can be found within the container at the path `/var/log/supervisor/`.  A file is kept for both the stdout and stderr of the processes managed by supervisord.  Additionally, you can use the `tail` command provided by supervisorctl.
 
-Alternatively, to tail all logs into the containers output for all services append the `--logs` option.
+Alternatively, to tail all logs into the container's output for all services, append the `--logs` option.
 
 ### Accessing databases
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ You can learn more about what commands are available by using the `help` command
 
 Logs can be found within the container at the path `/var/log/supervisor/`.  A file is kept for both the stdout and stderr of the processes managed by supervisord.  Additionally, you can use the `tail` command provided by supervisorctl.
 
+Alternatively, to tail all logs into the containers output for all services append the `--logs` option.
+
 ### Accessing databases
 
 The point of this project is to make running stellar's software within your own infrastructure easier, so that your software can more easily integrate with the stellar network.  In many cases, you can integrate with horizon's REST API, but often times you'll want direct access to the database either horizon or stellar-core provide.  This allows you to craft your own custom sql queries against the stellar network data.

--- a/start
+++ b/start
@@ -55,8 +55,8 @@ function main() {
   if [ "$ENABLE_LOGS" = "true" ]; then
     print_service_logs &
     start \
-      >  >(sed "s/^/${cyan}quickstart  | $clear/") \
-      2> >(sed "s/^/${cyan}quickstart  | $clear/" >&2)
+      >  >(sed "s/^/${cyan}quickstart   | $clear/") \
+      2> >(sed "s/^/${cyan}quickstart   | $clear/" >&2)
   else
     start
   fi

--- a/start
+++ b/start
@@ -453,8 +453,8 @@ function exec_supervisor() {
   upgrade_standalone &
   service_status &
   exec supervisord -n -c $SUPHOME/etc/supervisord.conf \
-    > >(sed 's/^/supervisor: /') \
-    2> >(sed 's/^/supervisor: /' >&2)
+    > >(sed -u 's/^/supervisor: /') \
+    2> >(sed -u 's/^/supervisor: /' >&2)
 }
 
 function print_service_logs() {

--- a/start
+++ b/start
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 set -e
 
+clear=$(echo -e "\e[0m")
+green=$(echo -e "\e[32m")
+blue=$(echo -e "\e[34m")
+purple=$(echo -e "\e[35m")
+cyan=$(echo -e "\e[36m")
+
 export STELLAR_HOME="/opt/stellar"
 export PGHOME="$STELLAR_HOME/postgresql"
 export SUPHOME="$STELLAR_HOME/supervisor"
@@ -15,6 +21,7 @@ export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432
 
+: "${ENABLE_LOGS:=false}"
 : "${ENABLE_HORIZON_CAPTIVE_CORE:=false}"
 : "${ENABLE_SOROBAN_RPC:=false}"
 : "${ENABLE_CORE_MANUAL_CLOSE:=false}"
@@ -24,10 +31,6 @@ QUICKSTART_INITIALIZED=false
 CURRENT_POSTGRES_PID=""
 
 function main() {
-  echo ""
-  echo "Starting Stellar Quickstart"
-  echo ""
-
   process_args $*
   if [ "$NETWORK" != "standalone" ] && [ "$ENABLE_HORIZON_CAPTIVE_CORE" = "true" ]; then
     echo "--enable-horizon-captive-core usage only supported on standalone networks" >&2
@@ -49,6 +52,18 @@ function main() {
     echo "--enable-core-artificially-accelerate-time-for-testing is only supported without captive core" >&2
     exit 1
   fi
+  if [ "$ENABLE_LOGS" = "true" ]; then
+    print_service_logs &
+    start \
+      >  >(sed "s/^/${cyan}quickstart  | $clear/") \
+      2> >(sed "s/^/${cyan}quickstart  | $clear/" >&2)
+  else
+    start
+  fi
+}
+
+function start() {
+  echo "Starting Stellar Quickstart"
 
   echo "mode: $STELLAR_MODE"
   echo "network: $NETWORK ($NETWORK_PASSPHRASE)"
@@ -71,6 +86,9 @@ function process_args() {
     ARG="$1"
     shift
     case "${ARG}" in
+    --logs)
+      ENABLE_LOGS=true
+      ;;
     --testnet)
       NETWORK="testnet"
       ;;
@@ -437,6 +455,20 @@ function exec_supervisor() {
   exec supervisord -n -c $SUPHOME/etc/supervisord.conf \
     > >(sed 's/^/supervisor: /') \
     2> >(sed 's/^/supervisor: /' >&2)
+}
+
+function print_service_logs() {
+  # Wait for supervisord to be up.
+  while ! supervisorctl pid > /dev/null ; do
+    sleep 1;
+  done
+  # Start tailing logs from notable services.
+  supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
+  supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
+  supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
+  if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
+    supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
+  fi
 }
 
 # run_silent is a utility function that runs a command with an abbreviated


### PR DESCRIPTION
### What
Add a `--logs` option that when set causes the logs of services (stellar-core, horizon, soroban-rpc) to be output to the container logs. Logs are disambiguated from each other by prefixing them with their service name colored, similar to the same output formatting of other popular tools like docker-compose, and foreman.

### Why
When the image runs for most development and testing use cases a developer doesn't need to see the logs, but when they do, they need to shell into the container or mount a volume to capture those logs as files. Working on the image is a common time that we need to be viewing the logs. Being able to chuck an option on the end to get all the logs at once is much more convenient than needing to shell in and grep files.

The output of the application is unchanged when the option is not enabled.

When the option is enabled, logs are outputted in this form:
<img width="1144" alt="Screenshot 2023-01-25 at 2 08 37 PM" src="https://user-images.githubusercontent.com/351529/214702724-a714d05c-d013-4837-9b7b-b960a61f3f50.png">

Close #405