### PR TITLE
soroban rpc make requires cargo for preflight step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - if: steps.cache.outputs.cache-hit != 'true'
       name: Build Stellar-Soraban-Rpc Image
-      run: docker buildx build --platform linux/${{ inputs.arch }} -f cmd/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc:${{ inputs.arch }} -o type=docker,dest=/tmp/image https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
+      run: docker buildx build --platform linux/${{ inputs.arch }} -f Dockerfile.soroban-rpc --target builder -t stellar-soroban-rpc:${{ inputs.arch }} -o type=docker,dest=/tmp/image . --build-arg REF="${{ env.SOROBAN_TOOLS_REPO_BRANCH }}"
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:

--- a/Dockerfile.soroban-rpc
+++ b/Dockerfile.soroban-rpc
@@ -1,0 +1,21 @@
+FROM golang:1.19 AS builder
+
+ARG REF
+WORKDIR /go/src/github.com/stellar/soroban-tools
+RUN git clone https://github.com/stellar/soroban-tools /go/src/github.com/stellar/soroban-tools
+RUN git fetch origin ${REF}
+RUN git checkout ${REF}
+RUN git config --global --add safe.directory "/go/src/github.com/stellar/soroban-tools"
+
+ENV CARGO_HOME=/rust/.cargo
+ENV RUSTUP_HOME=/rust/.rust
+ENV PATH="/usr/local/go/bin:$CARGO_HOME/bin:${PATH}"
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN apt-get clean
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+
+RUN make build-soroban-rpc
+RUN mv soroban-rpc /bin/soroban-rpc

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-deps-friendbot:
 	docker build -t stellar-friendbot:$(TAG) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REF)
 
 build-deps-soroban-rpc:
-	docker build -t stellar-soroban-rpc:$(TAG) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REF)
+	docker build -t stellar-soroban-rpc:$(TAG) -f Dockerfile.soroban-rpc --target builder . --build-arg REF="$(SOROBAN_TOOLS_REF)"
 
 # the build-deps have the four dependencies for the building of the
 # dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies


### PR DESCRIPTION
started seeing build errors from `make build`, noticed soroban-rpc requires using its makefile now, there are multiple steps involved in building it that have to be followed.

updated quickstart make and gh workflow to use intermediate dockerfile to run the soroban rpc make.