### PR TITLE
Fix PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,8 +267,8 @@ jobs:
         go run test_soroban_rpc_up.go
 
   push-pr:
-    # Push image to registry after build for pull requests.
-    if: ${{ github.event_name == 'pull_request' }}
+    # Push image to registry after build for pull requests from a local branch.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: build
     permissions:
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,8 +267,8 @@ jobs:
         go run test_soroban_rpc_up.go
 
   push-pr:
-    # Push image to registry after build for pull requests from a local branch.
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    # Push image to registry after build for pull requests.
+    if: ${{ github.event_name == 'pull_request' }}
     needs: build
     permissions:
       packages: write

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -27,6 +27,7 @@ env:
 jobs:
 
   push:
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       packages: write
       statuses: write


### PR DESCRIPTION
### What
Don't push manifests for forks.

### Why
We don't push images for forks, but looks like we try and push a manifest for forks and it errors saying the images don't exist. The error is valid, the images don't exist because we don't push them.