### PR TITLE
Support arm64 on :latest variant

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -22,7 +22,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [amd64]
+    needs: [manifest]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -35,7 +35,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       arch: amd64
-      tag: latest
+      tag: latest-amd64
       core_ref: v19.7.0
       go_ref: horizon-v2.23.0
       soroban_tools_ref: v0.4.0
@@ -50,3 +50,36 @@ jobs:
             { "network": "pubnet", "options": "--enable-horizon-captive-core --enable-core-artificially-accelerate-time-for-testing" },
           ]
         }
+
+  arm64:
+    uses: ./.github/workflows/build.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    with:
+      arch: arm64
+      tag: latest-arm64
+      core_ref: v19.7.0
+      go_ref: horizon-v2.23.0
+      soroban_tools_ref: v0.4.0
+      test_matrix: |
+        {
+          "network": ["testnet", "pubnet", "standalone"],
+          "options": ["", "--enable-horizon-captive-core", "--enable-horizon-captive-core --enable-core-artificially-accelerate-time-for-testing"],
+          "exclude": [
+            { "network": "testnet", "options": "--enable-horizon-captive-core" },
+            { "network": "testnet", "options": "--enable-horizon-captive-core --enable-core-artificially-accelerate-time-for-testing" },
+            { "network": "pubnet", "options": "--enable-horizon-captive-core" },
+            { "network": "pubnet", "options": "--enable-horizon-captive-core --enable-core-artificially-accelerate-time-for-testing" },
+          ]
+        }
+
+  manifest:
+    needs: [amd64, arm64]
+    uses: ./.github/workflows/manifest.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    with:
+      tag: latest
+      images: ${{ needs.amd64.outputs.image }} ${{ needs.arm64.outputs.image }}


### PR DESCRIPTION
### What
Build an arm64 image for the :latest variant and publish a multi-arch manifest for :latest containing both amd64 and arm64.

### Why
In #416 the version of stellar-core for latest was upgraded to v19.7.0 which contained a fix for building for arm64. The latest variant is otherwise ready to be built for arm64 and was just waiting for this release.
