### PR TITLE
updated soroban repo versions to preview 7 tags

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -35,10 +35,10 @@ jobs:
     with:
       arch: amd64
       tag: soroban-dev-amd64
-      core_ref: c0ad35aa19297e112d71fcc5755458495f99a237
+      core_ref: 3a201d2b5ecee34d6dcc0466633783f27b7fa97c
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
-      go_ref: soroban-v0.0.4
-      soroban_tools_ref: v0.4.0
+      go_ref: soroban-v0.0.5
+      soroban_tools_ref: v0.5.0
       test_matrix: |
         {
           "network": ["standalone"],
@@ -53,11 +53,11 @@ jobs:
     with:
       arch: arm64
       tag: soroban-dev-arm64
-      core_ref: c0ad35aa19297e112d71fcc5755458495f99a237
+      core_ref: 3a201d2b5ecee34d6dcc0466633783f27b7fa97c
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: soroban-v0.0.4
-      soroban_tools_ref: v0.4.0
+      go_ref: soroban-v0.0.5
+      soroban_tools_ref: v0.5.0
       test_matrix: |
         {
           "network": ["standalone"],

--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -37,8 +37,8 @@ jobs:
       tag: soroban-dev-amd64
       core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
-      go_ref: soroban-v0.0.5
-      soroban_tools_ref: v0.5.0
+      go_ref: soroban-v0.0.6
+      soroban_tools_ref: v0.6.0
       test_matrix: |
         {
           "network": ["standalone"],
@@ -56,8 +56,8 @@ jobs:
       core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: soroban-v0.0.5
-      soroban_tools_ref: v0.5.0
+      go_ref: soroban-v0.0.6
+      soroban_tools_ref: v0.6.0
       test_matrix: |
         {
           "network": ["standalone"],

--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       arch: amd64
       tag: soroban-dev-amd64
-      core_ref: 3a201d2b5ecee34d6dcc0466633783f27b7fa97c
+      core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
       go_ref: soroban-v0.0.5
       soroban_tools_ref: v0.5.0
@@ -53,7 +53,7 @@ jobs:
     with:
       arch: arm64
       tag: soroban-dev-arm64
-      core_ref: 3a201d2b5ecee34d6dcc0466633783f27b7fa97c
+      core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: soroban-v0.0.5

--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -37,8 +37,8 @@ jobs:
       tag: soroban-dev-amd64
       core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
-      go_ref: soroban-v0.0.6
-      soroban_tools_ref: v0.6.0
+      go_ref: soroban-v0.0.6.1
+      soroban_tools_ref: v0.6.1
       test_matrix: |
         {
           "network": ["standalone"],
@@ -56,8 +56,8 @@ jobs:
       core_ref: 871accefc0c4a703c1321b4f0e48cf6e03b41960
       core_configure_flags: --disable-tests --enable-next-protocol-version-unsafe-for-production
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: soroban-v0.0.6
-      soroban_tools_ref: v0.6.0
+      go_ref: soroban-v0.0.6.1
+      soroban_tools_ref: v0.6.1
       test_matrix: |
         {
           "network": ["standalone"],

--- a/test_soroban_rpc_up.go
+++ b/test_soroban_rpc_up.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const timeout = 3 * time.Minute
+const timeout = 6 * time.Minute
 
 type RPCResult struct {
 	Status string `json:"status"`


### PR DESCRIPTION
Update the `soroban-dev` image to build from the Soroban Preview 7 component source tag versions.