### PR TITLE
Update stellar-core deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD dependencies /
 RUN ["chmod", "+x", "dependencies"]
 RUN /dependencies
 
-RUN apt-get -y install postgresql curl sqlite libc++abi1-12 libc++1-12
+RUN apt-get -y install libunwind8 postgresql curl sqlite libc++abi1-12 libc++1-12
 COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 
 COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD dependencies /
 RUN ["chmod", "+x", "dependencies"]
 RUN /dependencies
 
-RUN apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
+RUN apt-get -y install postgresql curl sqlite libc++abi1-12 libc++1-12
 COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 
 COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon


### PR DESCRIPTION
### What
Remove dependency iproute2. Update libc++ dependencies from 10 to 12.

### Why
It doesn't appear that iproute2 is required, as stellar-core is able to sync to testnet without issue when they aren't installed.

In the stellar-core repo the docker image uses version 12 now for libc++. We should install the same version here too.