### PR TITLE
Use ports for services when polling status

### DIFF
--- a/common/soroban-rpc/bin/start
+++ b/common/soroban-rpc/bin/start
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
- while ! $(curl --silent --location --request GET 'http://localhost:8000' | \
+ while ! $(curl --silent --location --request GET 'http://localhost:8001' | \
             jq --exit-status '.core_latest_ledger > 5 and .history_latest_ledger > 5' 2>/dev/null | \
             grep -o true || echo false );
  do

--- a/start
+++ b/start
@@ -583,7 +583,7 @@ function stellar_core_status() {
 function soroban_rpc_status() {
   echo "soroban rpc: waiting for ready state..."
   COUNTER=1
-  while ! $(curl --silent --location --request POST 'http://localhost:8000/soroban/rpc' \
+  while ! $(curl --silent --location --request POST 'http://localhost:8003/soroban/rpc' \
     --header 'Content-Type: application/json' \
     --data-raw '{ "jsonrpc": "2.0", "id": 10235, "method": "getHealth" }' | \
     jq --exit-status '.result.status == "healthy"' 2>/dev/null | grep -o true || echo false);
@@ -600,7 +600,7 @@ function soroban_rpc_status() {
 function horizon_status() {
   COUNTER=1
   echo "horizon: waiting for ingestion to catch up..."
-  while ! $(curl --silent --location --request GET 'http://localhost:8000' | \
+  while ! $(curl --silent --location --request GET 'http://localhost:8001' | \
     jq --exit-status '.core_latest_ledger > 5 and .history_latest_ledger > 5' 2>/dev/null | \
     grep -o true || echo false);
   do


### PR DESCRIPTION
### What
Use ports for services when polling status, instead of using the nginx port.

### Why
In some places we use the nginx port when polling the status of services, and in others we use the application port. In the places where the application port is used, there's no issue. In places where the nginx port is used, seeing curl or something during that status poll step getting stuck indefinitely. It's unclear why this is happening, but this seems to be a difference that doesn't need to be different.

I tested this deployed to digital ocean and it fixes the issue with the status polling not working.