### PR TITLE
Retain .git directory when building soroban-rpc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
     - name: Uses buildx
       uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
     - name: Build Stellar-Soroban-Rpc Image
-      run: docker buildx build --platform linux/${{ inputs.arch }} -f cmd/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc:${{ inputs.arch }} -o type=docker,dest=/tmp/image https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
+      run: docker buildx build --platform linux/${{ inputs.arch }} -f cmd/soroban-rpc/docker/Dockerfile --target build -t stellar-soroban-rpc:${{ inputs.arch }} -o type=docker,dest=/tmp/image https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }} --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
     - name: Upload Stellar-Friendbot Image
       uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-deps-friendbot:
 	docker build -t stellar-friendbot:$(TAG) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REF)
 
 build-deps-soroban-rpc:
-	docker build -t stellar-soroban-rpc:$(TAG) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REF)
+	docker build -t stellar-soroban-rpc:$(TAG) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
 
 # the build-deps have the four dependencies for the building of the
 # dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies


### PR DESCRIPTION
### What
Retain .git directory when building soroban-rpc via docker.

### Why
The soroban-rpc build process assumes the .git directory is present. Docker, when using buildkit, by default doesn't include the .git directory in the built image as an optimization.

There's an error popping out in builds of soroban-rpc about the .git directory missing.

It's unclear how long this has been going on for, or what impact it has had.

In any case it looks like soroban-rpc needs the .git directory, and we can tell Docker to keep it in the working directory. We already do this for stellar-core for the same reason.