### PR TITLE
Fix builds of soroban-rpc

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -58,6 +58,7 @@ jobs:
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: soroban-v0.0.7
       soroban_tools_ref: v0.7.0
+      soroban_rpc_build_runner_type: ubuntu-latest-8-cores
       test_matrix: |
         {
           "network": ["standalone"],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,10 @@ on:
         description: 'Git ref for the stellar/soroban-tools repo (soroban-rpc)'
         type: 'string'
         required: true
+      soroban_rpc_build_runner_type:
+        description: 'The GitHub Runner instance type to build soroban-rpc on'
+        type: 'string'
+        default: 'ubuntu-latest'
       test_matrix:
         description: 'JSON matrix for the test job'
         type: 'string'
@@ -118,7 +122,7 @@ jobs:
         path: /tmp/image
 
   build-stellar-soroban-rpc:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.soroban_rpc_build_runner_type }}
     steps:
     - if: inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18


### PR DESCRIPTION
### What
Increase CI resources when building soroban-rpc.

### Why
I've noticed that CI has started failing to build soroban-rpc while attempting to update the crates.io index. The logs are not decisive, but they look like resources are being exceeded. The resource most likely to be exceeded here is a free space limit.

Upping resources is the simplest way to address this problem without making changes to the soroban-rpc repo. We need to do this in a way that doesn't require changing the repo because we need to be able to build previously tagged versions of soroban-rpc.

In Rust 1.70 cargo, which will be released in 13 days, will move to using a sparse registry and it will no longer need to check out the entire index. When that happens we can revert this change.

We just seem to be unlucky this has started happening now.