### PR TITLE
Re-add caching of soroban-rpc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,13 +139,19 @@ jobs:
   build-stellar-soroban-rpc:
     runs-on: ${{ inputs.soroban_rpc_build_runner_type }}
     steps:
-    - if: inputs.arch == 'arm64'
+    - id: cache
+      uses: actions/cache@v3
+      with:
+        path: /tmp/image
+        key: image-stellar-soroban-rpc-${{ inputs.arch }}-${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
+    - if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       with:
         platforms: arm64
-    - name: Uses buildx
+    - if: steps.cache.outputs.cache-hit != 'true'
       uses: docker/setup-buildx-action@5146db6c4d81fbfd508899f851bbb3883a96ff9f
-    - name: Build Stellar-Soroban-Rpc Image
+    - if: steps.cache.outputs.cache-hit != 'true'
+      name: Build Stellar-Soroban-Rpc Image
       run: >
         docker buildx build --platform linux/${{ inputs.arch }} 
         -f cmd/soroban-rpc/docker/Dockerfile --target build 
@@ -153,7 +159,7 @@ jobs:
         -o type=docker,dest=/tmp/image 
         --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true 
         https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
-    - name: Upload Stellar-Friendbot Image
+    - name: Upload Stellar-Soroban-Rpc Image
       uses: actions/upload-artifact@v2
       with:
         name: image-stellar-soroban-rpc-${{ inputs.arch }}


### PR DESCRIPTION
### What
Re-add caching of soroban-rpc.

### Why
It was removed because soroban-rpc builds were occurring from a moving branch.

We're back to using release tags now.

Soroban rpc build process is so slow it rivals stellar-core. We really need caching to keep quickstart PR builds something we can iterate on.