### PR TITLE
Fix #456 where soroban-rpc logs waiting forever

### DIFF
--- a/start
+++ b/start
@@ -577,7 +577,7 @@ function stellar_core_status() {
 function soroban_rpc_status() {
   echo "soroban rpc: waiting for ready state..."
   COUNTER=1
-  while ! $(curl --silent --location --request POST 'http://localhost:8000/soroban/rpc' \
+  while ! $(curl --silent --location --request POST 'http://localhost:8003' \
     --header 'Content-Type: application/json' \
     --data-raw '{ "jsonrpc": "2.0", "id": 10235, "method": "getHealth" }' | \
     jq --exit-status '.result.status == "healthy"' 2>/dev/null | grep -o true || echo false);

--- a/start
+++ b/start
@@ -577,7 +577,7 @@ function stellar_core_status() {
 function soroban_rpc_status() {
   echo "soroban rpc: waiting for ready state..."
   COUNTER=1
-  while ! $(curl --silent --location --request POST 'http://localhost:8003/soroban/rpc' \
+  while ! $(curl --silent --location --request POST 'http://localhost:8000/soroban/rpc' \
     --header 'Content-Type: application/json' \
     --data-raw '{ "jsonrpc": "2.0", "id": 10235, "method": "getHealth" }' | \
     jq --exit-status '.result.status == "healthy"' 2>/dev/null | grep -o true || echo false);


### PR DESCRIPTION
Fixes https://github.com/stellar/quickstart/issues/456

Previously the `start` script was polling for soroban-rpc on the wrong port+path, so the health check would never succeed. Not sure why it was working before.