### PR TITLE
bump horizon ref to 2.26.0

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -37,7 +37,7 @@ jobs:
       arch: amd64
       tag: latest-amd64
       core_ref: v19.11.0
-      go_ref: horizon-v2.25.0
+      go_ref: horizon-v2.26.0
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -58,7 +58,7 @@ jobs:
       arch: arm64
       tag: latest-arm64
       core_ref: v19.11.0
-      go_ref: horizon-v2.25.0
+      go_ref: horizon-v2.26.0
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -38,7 +38,7 @@ jobs:
       arch: amd64
       tag: testing-amd64
       core_ref: v19.11.0
-      go_ref: horizon-v2.25.0
+      go_ref: horizon-v2.26.0
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -59,7 +59,7 @@ jobs:
       arch: arm64
       tag: testing-arm64
       core_ref: v19.11.0
-      go_ref: horizon-v2.25.0
+      go_ref: horizon-v2.26.0
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {


### PR DESCRIPTION
updating the non-soroban image versions to latest horizon 2.26.0 release.