### PR TITLE
update horizon to 2.26.1-374

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -37,7 +37,7 @@ jobs:
       arch: amd64
       tag: latest-amd64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.1-374
+      go_ref: horizon-v2.26.1
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -58,7 +58,7 @@ jobs:
       arch: arm64
       tag: latest-arm64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.1-374
+      go_ref: horizon-v2.26.1
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -37,7 +37,7 @@ jobs:
       arch: amd64
       tag: latest-amd64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.0
+      go_ref: horizon-v2.26.1-374
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -58,7 +58,7 @@ jobs:
       arch: arm64
       tag: latest-arm64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.0
+      go_ref: horizon-v2.26.1-374
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -38,7 +38,7 @@ jobs:
       arch: amd64
       tag: testing-amd64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.0
+      go_ref: horizon-v2.26.1-374
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -59,7 +59,7 @@ jobs:
       arch: arm64
       tag: testing-arm64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.0
+      go_ref: horizon-v2.26.1-374
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -38,7 +38,7 @@ jobs:
       arch: amd64
       tag: testing-amd64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.1-374
+      go_ref: horizon-v2.26.1
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {
@@ -59,7 +59,7 @@ jobs:
       arch: arm64
       tag: testing-arm64
       core_ref: v19.12.0
-      go_ref: horizon-v2.26.1-374
+      go_ref: horizon-v2.26.1
       soroban_tools_ref: v0.4.0
       test_matrix: |
         {


### PR DESCRIPTION
### What
update horizon to 2.26.1-374

### Why
patch for horizon issue

### Testing
will validate upon landing

### Issue addressed by this PR
N/A