### PR TITLE
Use offline-close to prepare a checkpoint before other services boot

### DIFF
--- a/start
+++ b/start
@@ -368,6 +368,13 @@ function init_stellar_core() {
     pushd /tmp/stellar-core/history/vs
     python3 -m http.server 1570 > /dev/null 2>&1 &
     popd
+
+    # Skip ahead the first 64 ledgers, writing checkpoints, so that the network
+    # starts with a checkpoint available in the archive. Applications like
+    # Horizon, Soroban-RPC require a checkpoint to start ingestion. Without one
+    # they will wait for a checkpoint to be naturally produced which delays
+    # those services reaching a ready state.
+    run_silent "skip-to-first-checkpoint" sudo -u stellar stellar-core --conf etc/stellar-core.cfg offline-close 64
   fi
 
   touch .quickstart-initialized


### PR DESCRIPTION
### What
Use offline-close to prepare a checkpoint before other services boot.

### Why
To reduce the time that soroban-rpc and horizon (running captive-core) need to wait before they can start ingesting to zero. Both need a checkpoint to be published before they can ingest, and a checkpoint isn't published by default until ledger 64, or when accelerated, ledger 8.

This change closes the first 64 ledgers to ensure in either case a checkpoint is written before services start.

Technically standalone always runs in accelerated mode and closing the first 8 would be sufficient. The fact that standalone uses accelerated mode was a work around introduced in https://github.com/stellar/quickstart/pull/448 to speed up the first checkpoint to reduce the delay. With this change the checkpoint speed up will be unnecessary and we will likely change it back in https://github.com/stellar/quickstart/pull/453.

The offline-close command was recently added to stellar-core and is available in all verisons of stellar-core that are used in the different variants of the docker image (`:latest`, `:testing`, `:soroban-dev`).