### PR TITLE
Remove unnecessary packages and steps from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ EXPOSE 11625
 EXPOSE 11626
 
 ADD dependencies /
-RUN ["chmod", "+x", "dependencies"]
 RUN /dependencies
 
-RUN apt-get -y install libunwind8 postgresql curl sqlite libc++abi1-12 libc++1-12
 COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 
 COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon

--- a/dependencies
+++ b/dependencies
@@ -4,12 +4,13 @@ set -e
 # dependencies
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y curl wget git apt-transport-https \
-                   libpq-dev libsqlite3-dev libsasl2-dev \
+apt-get install -y curl apt-transport-https \
                    postgresql-client postgresql postgresql-contrib \
-                   sudo vim zlib1g-dev supervisor psmisc \
-                   nginx rsync jq netcat # Parsing stellar-core JSON for standalone network and checking core HTTP server
+                   sudo supervisor psmisc \
+                   nginx rsync jq netcat \
+                   libunwind8 sqlite libc++abi1-12 libc++1-12
 apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 chown -R www-data:www-data /var/lib/nginx
 


### PR DESCRIPTION
### What

Remove unnecessary packages and steps from the image.

### Why

We're installing things and leaving things in the image that take up about 25% of the image, but aren't needed for it to run. This image is ideally easy for a wide range of people to use. Not everyone has fast internet.

Some of the tools being removed were never needed and are only needed if building from source. Others look like they were there out of convenience when hacking on the image. For that latter case, folks can install whatever they need as they need it.