### PR TITLE
Add convenience targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,51 @@
-__PHONY__: build build-deps
+__PHONY__: run logs build build-deps build-deps-core build-deps-horizon build-deps-friendbot build-deps-soroban-rpc
 
 TAG?=dev
 CORE_REF?=master
 CORE_CONFIGURE_FLAGS?=--disable-tests
-SOROBAN_TOOLS_REF?=main
-GO_REF?=$(shell ./scripts/soroban_repo_to_horizon_repo.sh $(SOROBAN_TOOLS_REF))
+SOROBAN_RPC_REF?=main
+HORIZON_REF?=$(shell ./scripts/soroban_repo_to_horizon_repo.sh $(SOROBAN_RPC_REF))
+FRIENDBOT_REF?=$(HORIZON_REF)
 
-build-deps-core:
-	docker build -t stellar-core:$(TAG) -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS="$(CORE_CONFIGURE_FLAGS)"
+run:
+	docker run --rm --name stellar -p 8000:8000 stellar/quickstart:$(TAG) --standalone --enable-soroban-rpc
 
-build-deps-horizon:
-	docker build -t stellar-horizon:$(TAG) -f Dockerfile.horizon --target builder . --build-arg REF="$(GO_REF)"
+logs:
+	docker exec stellar /bin/sh -c 'tail -F /var/log/supervisor/*'
 
-build-deps-friendbot:
-	docker build -t stellar-friendbot:$(TAG) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(GO_REF)
+build-latest:
+	$(MAKE) build TAG=latest \
+		CORE_REF=v19.13.0 \
+		HORIZON_REF=horizon-v2.26.1 \
+		SOROBAN_RPC_REF=v0.4.0
 
-build-deps-soroban-rpc:
-	docker build -t stellar-soroban-rpc:$(TAG) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_TOOLS_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+build-testing:
+	$(MAKE) build TAG=testing \
+		CORE_REF=v19.13.0 \
+		HORIZON_REF=horizon-v2.26.1 \
+		SOROBAN_RPC_REF=v0.4.0
 
-# the build-deps have the four dependencies for the building of the
-# dockers for core, horizon, friendbot and soroban-rpc. Specifying these as dependencies
-# allow the make to run these in parallel when sufficient paralalism is specified using the -j option.
+build-soroban-dev:
+	$(MAKE) build TAG=soroban-dev \
+		CORE_REF=soroban-preview-10-July20 \
+		CORE_CONFIGURE_FLAGS='--disable-tests --enable-next-protocol-version-unsafe-for-production' \
+		HORIZON_REF=soroban-v0.0.9.1 \
+		SOROBAN_RPC_REF=v0.9.2
+
+build:
+	$(MAKE) -j 4 build-deps
+	docker build -t stellar/quickstart:$(TAG) -f Dockerfile . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:$(CORE_REF) --build-arg HORIZON_IMAGE_REF=stellar-horizon:$(HORIZON_REF) --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:$(FRIENDBOT_REF) --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:$(SOROBAN_RPC_REF)
+
 build-deps: build-deps-core build-deps-horizon build-deps-friendbot build-deps-soroban-rpc
 
-build: build-deps
-	docker build -t stellar/quickstart:$(TAG) -f Dockerfile . --build-arg STELLAR_CORE_IMAGE_REF=stellar-core:$(TAG) --build-arg HORIZON_IMAGE_REF=stellar-horizon:$(TAG) --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:$(TAG) --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:$(TAG)
+build-deps-core:
+	docker build -t stellar-core:$(CORE_REF) -f docker/Dockerfile.testing https://github.com/stellar/stellar-core.git#$(CORE_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS="$(CORE_CONFIGURE_FLAGS)"
+
+build-deps-horizon:
+	docker build -t stellar-horizon:$(HORIZON_REF) -f Dockerfile.horizon --target builder . --build-arg REF="$(HORIZON_REF)"
+
+build-deps-friendbot:
+	docker build -t stellar-friendbot:$(FRIENDBOT_REF) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(FRIENDBOT_REF)
+
+build-deps-soroban-rpc:
+	docker build -t stellar-soroban-rpc:$(SOROBAN_RPC_REF) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_RPC_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true


### PR DESCRIPTION
### What
Add targets to Makefile for building the image in the latest, testing, and soroban-dev configurations. Reorganize the Makefile so it is top down rather than bottom up.

### Why
To make it easier to develop on this image and build it from source locally.