### PR TITLE
Remove instructions from readme about customizing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,11 @@ As part of launching, an ephemeral mode container will generate a random passwor
 
 ### Persistent mode
 
-In comparison to ephemeral mode, persistent mode is more complicated to operate, but also more powerful.  Persistent mode uses a mounted host volume, a directory on the host machine that is exposed to the running docker container, to store all database data as well as the configuration files used for running services.  This allows you to manage and modify these files from the host system.
+In comparison to ephemeral mode, persistent mode is more complicated to operate, but also more powerful.  Persistent mode uses a mounted host volume, a directory on the host machine that is exposed to the running docker container, to store all database data as well as the configuration files used for running services. This allows you to manage and modify these files from the host system.
+
+Note that there is no guarantee that the organization of the files of the volume will remain consistent between releases of the image, that occur on every commit to the stellar/quickstart repository. At anytime new files may be added, old files removed, or dependencies and references between them changed. For this reason persistent mode is primarily intended for running short lived test instances for development. If consistency is required over any period of time use [image digest references] to pin to a specific build.
+
+[image digest references]: https://docs.docker.com/engine/reference/run/#imagedigest
 
 Starting a persistent mode container is the same as the ephemeral mode with one exception:
 
@@ -186,34 +190,6 @@ Upon launching a persistent mode container for the first time, the launch script
 1.  Run an interactive session of the container at first, ensuring that all services start and run correctly.
 2.  Shut down the interactive container (using Ctrl-C).
 3.  Start a new container using the same host directory in the background.
-
-
-### Customizing configurations
-
-To customize the configurations that both stellar-core and horizon use, you must use persistent mode.  The default configurations will be copied into the data directory upon launching a persistent mode container for the first time.  Use the diagram below to learn about the various configuration files that can be customized.
-
-```
-  /opt/stellar
-  |-- core
-  |   `-- etc
-  |       `-- stellar-core.cfg  # Stellar core config
-  |-- horizon
-  |   `-- etc
-  |       `-- horizon.env       # A shell script that exports horizon's config
-  |-- postgresql
-  |   `-- etc
-  |       |-- postgresql.conf   # Postgresql root configuration file
-  |       |-- pg_hba.conf       # Postgresql client configuration file
-  |       `-- pg_ident.conf     # Postgresql user mapping file
-  `-- supervisor
-      `-- etc
-  |       `-- supervisord.conf  # Supervisord root configuration
-```
-
-It is recommended that you stop the container before editing any of these files, then restart the container after completing your customization.
-
-*NOTE:* Be wary of editing these files.  It is possible to break the services started within this container with a bad edit.  It's recommended that you learn about managing the operations of each of the services before customizing them, as you are taking responsibility for maintaining those services going forward.
-
 
 ## Regarding user accounts
 


### PR DESCRIPTION
### What

Remove instructions from readme about customizing files on persistent volumes.

### Why

The instructions currently set someone up to fail because they describe a use case that is misaligned with the goals of the image, and misaligned with the actual maintenance that takes place on this image.

This image is for development and testing, both in the local form, and in the form of being able to deploy the image to simple PaaS environments in a short lived form. (Note that helm charts and other methods for installing and hosting the Stellar services exist for longer form and more complex environments.)

The organization of the files is particularly brittle. When maintaining the image for its primary purpose it is common that we need to change the organization of the files in ways that make the image incompatible with users who have customized the files.

Given that we've broken how those files work in the past and nobody has spoken up there's some signal, or lack of signal, that suggests very few people are actually customizing the files.

Nothing about this change prevents someone from customizing the files. The files are still stored in the location that becomes persistent when used in persistent mode.

This change serves to stop promoting it as a recommended way to use the image.

The change also adds a note clarifying how there is no compatibility guarantee on the configuration files.

Close #478