### PR TITLE
updated core ref on build-soroban-dev target

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -34,7 +34,7 @@ jobs:
     with:
       arch: amd64
       tag: soroban-dev-amd64
-      core_ref: ecb24df104c2453a00fa5097d2e879d7731b9596
+      core_ref: v20.0.0rc1
       core_configure_flags: --disable-tests
       go_ref: soroban-v1.0.0-rc
       soroban_tools_ref: v20.0.0-rc1
@@ -52,7 +52,7 @@ jobs:
     with:
       arch: arm64
       tag: soroban-dev-arm64
-      core_ref: ecb24df104c2453a00fa5097d2e879d7731b9596
+      core_ref: v20.0.0rc1
       core_configure_flags: --disable-tests
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: soroban-v1.0.0-rc

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-testing:
 
 build-soroban-dev:
 	$(MAKE) build TAG=soroban-dev \
-		CORE_REF=ecb24df104c2453a00fa5097d2e879d7731b9596 \
+		CORE_REF=v20.0.0rc1 \
 		CORE_CONFIGURE_FLAGS='--disable-tests' \
 		HORIZON_REF=soroban-v1.0.0-rc \
 		SOROBAN_RPC_REF=v20.0.0-rc1

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-testing:
 
 build-soroban-dev:
 	$(MAKE) build TAG=soroban-dev \
-		CORE_REF=v20.0.0rc1 \
+		CORE_REF=ecb24df104c2453a00fa5097d2e879d7731b9596 \
 		CORE_CONFIGURE_FLAGS='--disable-tests' \
 		HORIZON_REF=soroban-v1.0.0-rc \
 		SOROBAN_RPC_REF=v20.0.0-rc1


### PR DESCRIPTION
consistent ref to the v20.0.0rc1 tag for core, used commit hash setting on earlier pr - https://github.com/stellar/quickstart/pull/483