### PR TITLE
Fix standalone -> local refs in container

### DIFF
--- a/start
+++ b/start
@@ -362,7 +362,7 @@ function init_stellar_core() {
   run_silent "finalize-core-config-run-local" perl -pi -e "s/__RUN_STANDALONE__/$RUN_STANDALONE/g" etc/stellar-core.cfg
   run_silent "finalize-core-config-manual-close" perl -pi -e "s/__MANUAL_CLOSE__/$ENABLE_CORE_MANUAL_CLOSE/g" etc/stellar-core.cfg
 
-  if [ "$NETWORK" = "standalone" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
+  if [ "$NETWORK" = "local" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
     run_silent "finalize-core-config-testing-soroban-high-limit-override-set-true" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__/TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE=true/g" etc/stellar-core.cfg
   else
     run_silent "finalize-core-config-testing-soroban-high-limit-override-unset" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__//g" etc/stellar-core.cfg
@@ -404,7 +404,7 @@ function init_horizon() {
     run_silent "finalize-horizon-captivecore-db" perl -pi -e "s*__DATABASE__*sqlite3://$HZHOME/captive-core/stellar.db*g" $HORIZON_CAPTIVE_CORE_CFG
     perl -pi -e "s/__NETWORK__/$NETWORK_PASSPHRASE/g" $HORIZON_CAPTIVE_CORE_CFG
 
-    if [ "$NETWORK" = "standalone" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
+    if [ "$NETWORK" = "local" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
       run_silent "finalize-horizon-captivecore-config-testing-soroban-high-limit-override-set-true" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__/TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE=true/g" $HORIZON_CAPTIVE_CORE_CFG
     else
       run_silent "finalize-horizon-captivecore-config-testing-soroban-high-limit-override-unset" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__//g" $HORIZON_CAPTIVE_CORE_CFG
@@ -452,7 +452,7 @@ function init_soroban_rpc() {
   perl -pi -e "s/__NETWORK__/$NETWORK_PASSPHRASE/g" $SOROBAN_RPC_CAPTIVE_CORE_CFG
   run_silent "finalize-core-config-enable-soroban-diagnostic-events" perl -pi -e "s/__ENABLE_SOROBAN_DIAGNOSTIC_EVENTS__/$ENABLE_SOROBAN_DIAGNOSTIC_EVENTS/g" $SOROBAN_RPC_CAPTIVE_CORE_CFG
 
-  if [ "$NETWORK" = "standalone" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
+  if [ "$NETWORK" = "local" ] && [ "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE}" = "true" ]; then
     run_silent "finalize-soroban-rpc-captivecore-config-testing-soroban-high-limit-override-set-true" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__/TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE=true/g" $SOROBAN_RPC_CAPTIVE_CORE_CFG
   else
     run_silent "finalize-soroban-rpc-captivecore-config-testing-soroban-high-limit-override-unset" perl -pi -e "s/__TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE__//g" $SOROBAN_RPC_CAPTIVE_CORE_CFG


### PR DESCRIPTION
### What
Change references to the standalone network to local that were added in https://github.com/stellar/quickstart/pull/492.

### Why
The standalone network was renamed to local, and that PR used the name standalone for some checks, meaning the result of the checks will never run.