### PR TITLE
Fix friendbot URL set for testnet

### DIFF
--- a/testnet/soroban-rpc/etc/soroban-rpc.cfg
+++ b/testnet/soroban-rpc/etc/soroban-rpc.cfg
@@ -1,6 +1,6 @@
 ENDPOINT="localhost:8003"
 ADMIN_ENDPOINT="__SOROBAN_RPC_ADMIN_ENDPOINT__"
-FRIENDBOT_URL="https://friendbot-testnet.stellar.org/"
+FRIENDBOT_URL="https://friendbot.stellar.org/"
 NETWORK_PASSPHRASE="__NETWORK__"
 STELLAR_CORE_URL="http://localhost:11626"
 CAPTIVE_CORE_CONFIG_PATH="/opt/stellar/soroban-rpc/etc/stellar-captive-core.cfg"


### PR DESCRIPTION
### What
Change the friendbot URL set for testnet to `https://friendbot.stellar.org/`.

### Why
It's set to `https://friendbot-testnet.stellar.org/` which doesn't exist. Looks like we typod the name in the config.

This prevents anyone from using quickstart to fund accounts when using the soroban-cli.

Close #505