### PR TITLE
Manage history-archive http server with supervisor

### DIFF
--- a/local/supervisor/etc/supervisord.conf.d/history-archive.conf
+++ b/local/supervisor/etc/supervisord.conf.d/history-archive.conf
@@ -1,0 +1,9 @@
+[program:history-archive]
+user=stellar
+directory=/tmp/stellar-core/history/vs
+command=/usr/bin/python3 -m http.server 1570
+autostart=true
+autorestart=true
+startretries=100
+priority=10
+redirect_stderr=true

--- a/start
+++ b/start
@@ -233,6 +233,7 @@ function copy_defaults() {
       cp /opt/stellar-default/$NETWORK/supervisor/etc/supervisord.conf.d/soroban-rpc.conf $SUPHOME/etc/supervisord.conf.d 2>/dev/null || true
     fi
     cp /opt/stellar-default/$NETWORK/supervisor/etc/supervisord.conf.d/friendbot.conf $SUPHOME/etc/supervisord.conf.d 2>/dev/null || true
+    cp /opt/stellar-default/$NETWORK/supervisor/etc/supervisord.conf.d/history-archive.conf $SUPHOME/etc/supervisord.conf.d 2>/dev/null || true
   fi
 
   if [ -d $COREHOME/etc ]; then
@@ -367,10 +368,6 @@ function init_stellar_core() {
     run_silent "init-core-scp" sudo -u stellar stellar-core force-scp --conf etc/stellar-core.cfg
 
     run_silent "init-history" sudo -u stellar stellar-core new-hist vs --conf $COREHOME/etc/stellar-core.cfg
-    # Start local history server
-    pushd /tmp/stellar-core/history/vs
-    python3 -m http.server 1570 > /dev/null 2>&1 &
-    popd
   fi
 
   touch .quickstart-initialized


### PR DESCRIPTION
### What
Remove the python3 http server that is started as a background job of the main process and replace it with running the same http server with supervisor.

### Why
The history archive http server is a critical component of the quickstart image when run in local mode as it serves the history archives for horizon, soroban-rpc.

Today the history archive http server is run as a background job from the start script, and its logs are sent to /dev/null. This gives us no visibility into what its doing, if its still running, and if it encountered any issues, what they are.

We use supervisor to run long running services in the quickstart image and there's no reason I can see why we wouldn't also use it for the history archive http server.

The reason I care about this today is there was a case where someone was experiencing issues and the logs appeared as if the history archive wasn't  available. Because the history archive wasn't managed by supervisor there was no way to debug if it was still running or what it was doing.