### PR TITLE
Update testing/soroban-dev with stellar-core v20.0.0-rc.2.1

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -35,7 +35,7 @@ jobs:
     with:
       arch: amd64
       tag: soroban-dev-amd64
-      core_ref: v20.0.0rc2
+      core_ref: v20.0.0-rc.2.1
       core_supports_testing_soroban_high_limit_override: "true"
       go_ref: horizon-v2.27.0-rc1
       soroban_tools_ref: v20.0.0-rc4
@@ -53,7 +53,7 @@ jobs:
     with:
       arch: arm64
       tag: soroban-dev-arm64
-      core_ref: v20.0.0rc2
+      core_ref: v20.0.0-rc.2.1
       core_supports_testing_soroban_high_limit_override: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0-rc1

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       arch: amd64
       tag: testing-amd64
-      core_ref: v20.0.0rc2
+      core_ref: v20.0.0-rc.2.1
       core_supports_testing_soroban_high_limit_override: "true"
       go_ref: horizon-v2.27.0-rc1
       soroban_tools_ref: v20.0.0-rc4
@@ -58,7 +58,7 @@ jobs:
     with:
       arch: arm64
       tag: testing-arm64
-      core_ref: v20.0.0rc2
+      core_ref: v20.0.0-rc.2.1
       core_supports_testing_soroban_high_limit_override: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0-rc1

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ build-latest:
 
 build-testing:
 	$(MAKE) build TAG=testing \
-		CORE_REF=v20.0.0rc2 \
+		CORE_REF=v20.0.0-rc.2.1 \
 		CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE=true \
 		HORIZON_REF=horizon-v2.27.0-rc1 \
 		SOROBAN_RPC_REF=v20.0.0-rc4
 
 build-soroban-dev:
 	$(MAKE) build TAG=soroban-dev \
-		CORE_REF=v20.0.0rc2 \
+		CORE_REF=v20.0.0-rc.2.1 \
 		CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE=true \
 		HORIZON_REF=horizon-v2.27.0-rc1 \
 		SOROBAN_RPC_REF=v20.0.0-rc4


### PR DESCRIPTION
### What
Update testing/soroban-dev with stellar-core v20.0.0-rc.2.1.

### Why
To get a fix for stellar-core high limit override that is causing contracts that work on testnet and futurenet to not work on local.