### PR TITLE
Always enable Soroban diagnostic events on local

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -22,3 +22,6 @@ spec:
     - key: ENABLE_SOROBAN_RPC
       value: 'false'
       scope: RUN_TIME
+    - key: DISABLE_SOROBAN_DIAGNOSTIC_EVENTS
+      value: 'true'
+      scope: RUN_TIME

--- a/README.md
+++ b/README.md
@@ -91,12 +91,17 @@ To enable the Soroban RPC server provide the following command line flags when s
 
 The Soroban RPC Server will be avaialble on port 8000 of the container, and the base URL path for Soroban RPC will be `http://<container_host>:8000/soroban/rpc`. This endpoint uses [JSON-RPC](https://www.jsonrpc.org/specification) protocol. Refer to example usages in [soroban-example-dapp](https://github.com/stellar/soroban-example-dapp).
 
+To enable Soroban diagnostic events provide the following command line flag when starting the container:
+`--enable-soroban-diagnostic-events`
+
+In local network mode diagnostics are enabled by default and can be disabled with:
+`--disable-soroban-diagnostic-events`
+
 To enable soroban rpc admin endpoint for access to metrics and [Go pprof (profiling)](https://pkg.go.dev/net/http/pprof), include the `--enable-soroban-rpc-admin-endpoint` flag, the HTTP endpoint will be listening on container port 6061, which can be exposed with standard docker port rule `-p "6061:6061"`, the published endpoints are:
 ```
 http://<container_host>:6061/metrics
 http://<container_host>:6061/debug/pprof/
 ```
-
 
 ### Deploy to Digital Ocean
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,23 @@ To enable the Soroban RPC server provide the following command line flags when s
 
 The Soroban RPC Server will be avaialble on port 8000 of the container, and the base URL path for Soroban RPC will be `http://<container_host>:8000/soroban/rpc`. This endpoint uses [JSON-RPC](https://www.jsonrpc.org/specification) protocol. Refer to example usages in [soroban-example-dapp](https://github.com/stellar/soroban-example-dapp).
 
+To enable soroban rpc admin endpoint for access to metrics and [Go pprof (profiling)](https://pkg.go.dev/net/http/pprof), include the `--enable-soroban-rpc-admin-endpoint` flag, the HTTP endpoint will be listening on container port 6061, which can be exposed with standard docker port rule `-p "6061:6061"`, the published endpoints are:
+```
+http://<container_host>:6061/metrics
+http://<container_host>:6061/debug/pprof/
+```
+
+### Soroban Diagnostic Events
+
+Soroban diagnostic events contain logs about internal events that have occurred while a contract is executing. They're particularly useful for debugging why a contract trapped (panicked).
+
 To enable Soroban diagnostic events provide the following command line flag when starting the container:
 `--enable-soroban-diagnostic-events`
 
 In local network mode diagnostics are enabled by default and can be disabled with:
 `--disable-soroban-diagnostic-events`
 
-To enable soroban rpc admin endpoint for access to metrics and [Go pprof (profiling)](https://pkg.go.dev/net/http/pprof), include the `--enable-soroban-rpc-admin-endpoint` flag, the HTTP endpoint will be listening on container port 6061, which can be exposed with standard docker port rule `-p "6061:6061"`, the published endpoints are:
-```
-http://<container_host>:6061/metrics
-http://<container_host>:6061/debug/pprof/
-```
+_Note: Diagnostic events are unmetered and their execution is not metered or contrained by network limits or transaction resource limits. This means the resources consumed by an instance with diagnostic events enabled may exceed resources typically required by a deployment with diagnostic events disabled._
 
 ### Deploy to Digital Ocean
 

--- a/start
+++ b/start
@@ -49,6 +49,9 @@ function main() {
     echo "--randomize-network-passphrase is only supported in the local network" >&2
     exit 1
   fi
+  if [ "$NETWORK" = "local" ]; then
+    ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+  fi
   start
 }
 

--- a/start
+++ b/start
@@ -24,6 +24,7 @@ export PGPORT=5432
 : "${ENABLE_LOGS:=false}"
 : "${ENABLE_SOROBAN_RPC:=false}"
 : "${ENABLE_SOROBAN_DIAGNOSTIC_EVENTS:=false}"
+: "${DISABLE_SOROBAN_DIAGNOSTIC_EVENTS:=false}"
 : "${ENABLE_SOROBAN_RPC_ADMIN_ENDPOINT:=false}"
 : "${ENABLE_CORE_MANUAL_CLOSE:=false}"
 : "${CORE_SUPPORTS_TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE:=false}"
@@ -49,7 +50,7 @@ function main() {
     echo "--randomize-network-passphrase is only supported in the local network" >&2
     exit 1
   fi
-  if [ "$NETWORK" = "local" ]; then
+  if [ "$NETWORK" = "local" ] && [ "$DISABLE_SOROBAN_DIAGNOSTIC_EVENTS" = "false" ]; then
     ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
   fi
   start
@@ -119,6 +120,9 @@ function process_args() {
       ;;
     --enable-soroban-diagnostic-events)
       ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
+      ;;
+    --disable-soroban-diagnostic-events)
+      DISABLE_SOROBAN_DIAGNOSTIC_EVENTS=true
       ;;
     --enable-soroban-rpc-admin-endpoint)
       ENABLE_SOROBAN_RPC_ADMIN_ENDPOINT=true


### PR DESCRIPTION
### What
Always enable Soroban diagnostic events on local, unless explicitly disabled.

### Why
Most of the time when folks are using quickstart in local mode they're developing locally or running quickstart in CI. In these modes diagnostic events are critical for understanding what's happening when things go wrong, and debugging during testing and development.

Much like how we enable other test capabilities in local, we should enable diagnostics because that's the most sensible default for developing in local.

We shouldn't change the default for testnet/pubnet, because diagnostics cause unmetered execution and on testnet/pubnet there's no guarantee other peoples contracts being executed would not cause unreasonable resource consumption.

The addition of the ability to disable on local is so that the Digital Ocean template can turn it off since that is a deployed local instance.