### PR TITLE
Make friendbot work in testnet mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ are finalized faster than on deployed networks.
 
 *Note*: The local network in this container is not suitable for any production use as it has a fixed root account. Any private network intended for production use would also required a unique network passphrase.
 
+### Faucet (Friendbot)
+
+Stellar development/test networks use friendbot as a faucet for the native asset.
+
+When running in local, testnet, and futurenet modes friendbot is available on `:8000/friendbot` and can be used to fund a new account.
+
+For example:
+```
+$ curl http://localhost:8000/friendbot?addr=G...
+```
+
+_Note: In local mode a local friendbot is running. In testnet and futurenet modes requests to the local `:8000/friendbot` endpoint will be proxied to the friendbot deployments for the respective network._
+
 ### Soroban Development
 
 For local development of smart contracts on Stellar using [Soroban], run a `local` network and the Soroban stack locally via the `stellar/quickstart:testing` image:

--- a/common/nginx/etc/conf.d/horizon.conf
+++ b/common/nginx/etc/conf.d/horizon.conf
@@ -1,0 +1,4 @@
+location / {
+        proxy_set_header Host $http_host;
+        proxy_pass http://127.0.0.1:8001;
+}

--- a/common/nginx/etc/conf.d/soroban-rpc.conf
+++ b/common/nginx/etc/conf.d/soroban-rpc.conf
@@ -1,0 +1,6 @@
+location /soroban/rpc {
+        rewrite /soroban/rpc / break;
+        proxy_set_header Host $http_host;
+        proxy_pass http://127.0.0.1:8003;
+        proxy_redirect off;
+}

--- a/common/nginx/etc/nginx.conf
+++ b/common/nginx/etc/nginx.conf
@@ -12,23 +12,7 @@ http {
 
                 error_page 502 @502;
 
-                location /friendbot {
-                        rewrite /friendbot / break;
-                        proxy_pass http://127.0.0.1:8002;
-                        proxy_redirect off;
-                }
-
-                location / {
-                        proxy_set_header Host $http_host;
-                        proxy_pass http://127.0.0.1:8001;
-                }
-
-                location /soroban/rpc {
-                        rewrite /soroban/rpc / break;
-                        proxy_set_header Host $http_host;
-                        proxy_pass http://127.0.0.1:8003;
-                        proxy_redirect off;
-                }
+                include conf.d/*.conf;
 
                 location @502 {
                         return 502 "502 Bad Gateway";

--- a/futurenet/nginx/etc/conf.d/friendbot.conf
+++ b/futurenet/nginx/etc/conf.d/friendbot.conf
@@ -1,0 +1,8 @@
+location /friendbot {
+        rewrite /friendbot / break;
+        proxy_pass https://friendbot-futurenet.stellar.org;
+        proxy_ssl_server_name on;
+        proxy_ssl_name friendbot-futurenet.stellar.org;
+        proxy_set_header Host friendbot-futurenet.stellar.org;
+        proxy_redirect off;
+}

--- a/local/nginx/etc/conf.d/friendbot.conf
+++ b/local/nginx/etc/conf.d/friendbot.conf
@@ -1,0 +1,5 @@
+location /friendbot {
+        rewrite /friendbot / break;
+        proxy_pass http://127.0.0.1:8002;
+        proxy_redirect off;
+}

--- a/testnet/nginx/etc/conf.d/friendbot.conf
+++ b/testnet/nginx/etc/conf.d/friendbot.conf
@@ -1,0 +1,8 @@
+location /friendbot {
+        rewrite /friendbot / break;
+        proxy_pass https://friendbot.stellar.org;
+        proxy_ssl_server_name on;
+        proxy_ssl_name friendbot.stellar.org;
+        proxy_set_header Host friendbot.stellar.org;
+        proxy_redirect off;
+}


### PR DESCRIPTION
### What
Replace the single one nginx file with multiple nginx files, one for each service, and configure the friendbot config differently for testnet and futurenet to point to the hosted faucets.

### Why
So that developers can write tests against their local quickstart that use friendbot regardless of whether the quickstart is running in local mode, testnet mode, or futurenet mode.

Close #57