### PR TITLE
Output versions of software to container logs on start

### DIFF
--- a/start
+++ b/start
@@ -60,7 +60,7 @@ function main() {
 function start() {
   echo "Starting Stellar Quickstart"
 
-  echo "installed software:"
+  echo "versions:"
   echo "  stellar-core:"
   echo "$(stellar-core version 2>/dev/null | sed 's/^/    /')"
   echo "  horizon:"

--- a/start
+++ b/start
@@ -60,6 +60,14 @@ function main() {
 function start() {
   echo "Starting Stellar Quickstart"
 
+  echo "versions:"
+  echo "  stellar-core:"
+  echo "$(stellar-core version 2>/dev/null | sed 's/^/    /')"
+  echo "  horizon:"
+  echo "$(stellar-horizon version | sed 's/^/    /')"
+  echo "  soroban-rpc:"
+  echo "$(stellar-soroban-rpc version | sed 's/^/    /')"
+
   echo "mode: $STELLAR_MODE"
   echo "network: $NETWORK"
   echo "network passphrase: $NETWORK_PASSPHRASE"

--- a/start
+++ b/start
@@ -60,7 +60,7 @@ function main() {
 function start() {
   echo "Starting Stellar Quickstart"
 
-  echo "versions:"
+  echo "installed software:"
   echo "  stellar-core:"
   echo "$(stellar-core version 2>/dev/null | sed 's/^/    /')"
   echo "  horizon:"


### PR DESCRIPTION
### What
Output the version of stellar-core, horizon, and soroban-rpc to container logs on start.

### Example
```
Starting Stellar Quickstart
versions:
  stellar-core:
    v20.0.0-rc.2.1
    rust version: rustc 1.72.1 (d5c2e9c34 2023-09-13)
    soroban-env-host: 
        curr:
            package version: 20.0.0-rc1
            git version: f19ef13363a1e0cbff7b100c0599a1d63dea88a6
            ledger protocol version: 20
            pre-release version: 57
            rs-stellar-xdr:
                package version: 20.0.0-rc1
                git version: d5ce0c9e7aa83461773a6e81662067f35d39e4c1
                base XDR git version: 9ac02641139e6717924fdad716f6e958d0168491
  horizon:
    horizon-v2.27.0-rc1-(built-from-source)
    go1.20.10
  soroban-rpc:
    soroban-rpc 20.0.0-rc4 (bce5e56ba16ba977200b022c91f3eaf6282f47eb) HEAD
    stellar-xdr 9ac02641139e6717924fdad716f6e958d0168491
mode: ephemeral
network: local
network passphrase: Standalone Network ; February 2017
```

### Why
It's not uncommon to run a quickstart image without paying much attention to if it is the latest or not, or pulling before running. In cases where behavior doesn't seem right it could help with debugging if the versions of software used in the image are outputted into the console logs during start.

If it doesn't help the person running quickstart, it may help maintainers debug situations that are reported.

Close #516