### PR TITLE
update soroban dev image to rpc 20.0.2 for preflight fees padding

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -39,7 +39,7 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.27.0
       xdr_ref: v20.0.1
-      soroban_tools_ref: v20.0.0
+      soroban_tools_ref: v20.0.2
       test_matrix: |
         {
           "network": ["local"],
@@ -59,7 +59,7 @@ jobs:
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0
       xdr_ref: v20.0.1
-      soroban_tools_ref: v20.0.0
+      soroban_tools_ref: v20.0.2
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {


### PR DESCRIPTION
updated the image meant for futurenet(soroban-dev) to include the fix for preflight instruction padding - https://github.com/stellar/soroban-tools/pull/1127