### PR TITLE
Update Makefile versions for testing/soroban-dev to match the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ build-latest:
 
 build-testing:
 	$(MAKE) build TAG=testing \
+		XDR_REF=v20.0.1 \
 		CORE_REF=v20.0.1 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.27.0 \
@@ -40,7 +41,7 @@ build-soroban-dev:
 		CORE_REF=v20.0.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.27.0 \
-		SOROBAN_RPC_REF=v20.0.0
+		SOROBAN_RPC_REF=v20.0.2
 
 build:
 	$(MAKE) -j 4 build-deps


### PR DESCRIPTION
### What
Update Makefile versions for testing and soroban-dev to match the CI

### Why
At some point they got out of sync.