### PR TITLE
Fix unintended environment variable config passthrough to services

### DIFF
--- a/common/supervisor/etc/supervisord.conf.d/horizon.conf
+++ b/common/supervisor/etc/supervisord.conf.d/horizon.conf
@@ -8,5 +8,3 @@ priority=30
 # No idea why Horizon stdout goes to stderr log in supervisor... This is the
 # easiest fix.
 redirect_stderr=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0

--- a/common/supervisor/etc/supervisord.conf.d/horizon.conf
+++ b/common/supervisor/etc/supervisord.conf.d/horizon.conf
@@ -8,3 +8,5 @@ priority=30
 # No idea why Horizon stdout goes to stderr log in supervisor... This is the
 # easiest fix.
 redirect_stderr=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0

--- a/start
+++ b/start
@@ -555,10 +555,18 @@ function print_service_logs() {
   while ! supervisorctl pid > /dev/null ; do
     sleep 1;
   done
+  while true ; do
+    sleep 1;
+    echo "------------------"
+    echo "------------------"
+    cat "/var/log/supervisor/*"
+    echo "------------------"
+    echo "------------------"
+  done
   # Start tailing logs from notable services.
   # supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
   # supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
-  supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
+  # supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
   # if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
   #   supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
   # fi

--- a/start
+++ b/start
@@ -555,21 +555,13 @@ function print_service_logs() {
   while ! supervisorctl pid > /dev/null ; do
     sleep 1;
   done
-  while true ; do
-    sleep 1;
-    echo "------------------"
-    echo "------------------"
-    cat "/var/log/supervisor/*"
-    echo "------------------"
-    echo "------------------"
-  done
   # Start tailing logs from notable services.
-  # supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
-  # supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
-  # supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
-  # if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
-  #   supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
-  # fi
+  supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
+  supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
+  supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
+  if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
+    supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
+  fi
 }
 
 # run_silent is a utility function that runs a command with an abbreviated

--- a/start
+++ b/start
@@ -21,7 +21,6 @@ export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432
 
-: "${NETWORK:=testnet}"
 : "${ENABLE_LOGS:=false}"
 : "${ENABLE_SOROBAN_RPC:=false}"
 : "${ENABLE_SOROBAN_DIAGNOSTIC_EVENTS:=false}"
@@ -163,6 +162,11 @@ function process_args() {
       exit 1
     esac
   done
+
+  # TODO: ask for what network to use
+  if [ -z "$NETWORK" ]; then
+    NETWORK="testnet"
+  fi
 
   case "$NETWORK" in
   testnet)

--- a/start
+++ b/start
@@ -556,12 +556,12 @@ function print_service_logs() {
     sleep 1;
   done
   # Start tailing logs from notable services.
-  supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
-  supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
+  # supervisorctl tail -f stellar-core stdout > >(sed "s/^/${purple}stellar-core | $clear/") &
+  # supervisorctl tail -f stellar-core stderr > >(sed "s/^/${purple}stellar-core | $clear/" >&2) &
   supervisorctl tail -f horizon      stdout > >(sed  "s/^/${green}horizon      | $clear/") &
-  if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
-    supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
-  fi
+  # if [ "$ENABLE_SOROBAN_RPC" = "true" ]; then
+  #   supervisorctl tail -f soroban-rpc  stdout > >(sed "s/^/${blue}soroban-rpc  | $clear/") &
+  # fi
 }
 
 # run_silent is a utility function that runs a command with an abbreviated

--- a/start
+++ b/start
@@ -545,7 +545,11 @@ function exec_supervisor() {
   echo "supervisor: starting"
   upgrade_local &
   service_status &
-  exec supervisord -n -c $SUPHOME/etc/supervisord.conf \
+  # Run supervisord in a new environment (using `env -i`) because supervisord
+  # inherits the env vars of its environment for all subprocesses that get
+  # started. This is problematic for services that use the same environment
+  # variable name for things that the start script does, like NETWORK.
+  env -i supervisord -n -c $SUPHOME/etc/supervisord.conf \
     > >(sed -u 's/^/supervisor: /') \
     2> >(sed -u 's/^/supervisor: /' >&2)
 }

--- a/start
+++ b/start
@@ -21,6 +21,7 @@ export PGDATA="$PGHOME/data"
 export PGUSER="stellar"
 export PGPORT=5432
 
+: "${NETWORK:=testnet}"
 : "${ENABLE_LOGS:=false}"
 : "${ENABLE_SOROBAN_RPC:=false}"
 : "${ENABLE_SOROBAN_DIAGNOSTIC_EVENTS:=false}"
@@ -162,11 +163,6 @@ function process_args() {
       exit 1
     esac
   done
-
-  # TODO: ask for what network to use
-  if [ -z "$NETWORK" ]; then
-    NETWORK="testnet"
-  fi
 
   case "$NETWORK" in
   testnet)

--- a/start
+++ b/start
@@ -549,7 +549,7 @@ function exec_supervisor() {
   # inherits the env vars of its environment for all subprocesses that get
   # started. This is problematic for services that use the same environment
   # variable name for things that the start script does, like NETWORK.
-  env -i supervisord -n -c $SUPHOME/etc/supervisord.conf \
+  exec env -i supervisord -n -c $SUPHOME/etc/supervisord.conf \
     > >(sed -u 's/^/supervisor: /') \
     2> >(sed -u 's/^/supervisor: /' >&2)
 }


### PR DESCRIPTION
### What

Run supervisord in a new environment that doesn't inherit the shell.

### Why

Supervisord and its subprocesses inherit the shell's environment variables.

This is problematic since environment variables are a shared space and there's no guarantee that setting an environment variable would make sense for all sub processes.

We have a case where this has caused problems. The quickstart image uses the `NETWORK` environment variable, and so does Horizon. For the longest time we have had issues running the quickstart image in certain situations, and it turns out what those situations had in common was they were setting the network of the image via an environment variable `NETWORK` to a value that worked with the quickstart image start script but didn't work with Horizon. Some values worked for both, some didn't.

We should set environment variables for services explicitly, not broadly based on what the images env vars are.

This will allow us to use the quickstart image as a service in GitHub Actions where it must be configured using env vars,
and anywhere folks are already configuring it with env vars.

Close #541 