### PR TITLE
bump core for testing/soroban images to v20.1.0

### DIFF
--- a/.github/workflows/build-soroban-dev.yml
+++ b/.github/workflows/build-soroban-dev.yml
@@ -36,7 +36,7 @@ jobs:
       arch: amd64
       tag: soroban-dev-amd64
       xdr_ref: v20.0.2
-      core_ref: v20.0.2
+      core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.27.0
       soroban_tools_ref: v20.1.0
@@ -55,7 +55,7 @@ jobs:
       arch: arm64
       tag: soroban-dev-arm64
       xdr_ref: v20.0.2
-      core_ref: v20.0.2
+      core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -38,7 +38,7 @@ jobs:
       arch: amd64
       tag: testing-amd64
       xdr_ref: v20.0.2
-      core_ref: v20.0.2
+      core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.27.0
       soroban_tools_ref: v20.1.0
@@ -60,7 +60,7 @@ jobs:
       arch: arm64
       tag: testing-arm64
       xdr_ref: v20.0.2
-      core_ref: v20.0.2
+      core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0


### PR DESCRIPTION
update the testing for testnet and soroban-dev for futurenet images to use core v20.1.0