### PR TITLE
Rename :soroban-dev to :future

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -1,6 +1,6 @@
-name: Soroban-Dev
+name: Future
 
-# The `:soroban-dev` tag points to a build containing unreleased versions of
+# The `:future` tag points to a build containing unreleased versions of
 # software that have been informally released to the futurenet network.
 
 on:
@@ -34,7 +34,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       arch: amd64
-      tag: soroban-dev-amd64
+      tag: future-amd64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
@@ -53,7 +53,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       arch: arm64
-      tag: soroban-dev-arm64
+      tag: future-arm64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
@@ -74,5 +74,5 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
-      tag: soroban-dev
+      tag: future
       images: ${{ needs.amd64.outputs.image }} ${{ needs.arm64.outputs.image }}


### PR DESCRIPTION
### What
Rename :soroban-dev to :future

### Why
To the given the image a name that communicates intent, and connects it to the future network.

The name soroban-dev is now confusing. All quickstart image variants contain soroban now.

The releases of soroban-dev are typically related to the futurenet releases. They're experimental / preview releases that have no compatibility guarantees.

Close #530

### Merging
Dependent on feedback on this comment: https://github.com/stellar/quickstart/issues/530#issuecomment-1903217821