### PR TITLE
Update testing manifest file to use the latest core_ref v20.2.0rc1 for arm and amd builds

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -38,7 +38,7 @@ jobs:
       arch: amd64
       tag: testing-amd64
       xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      core_ref: v20.2.0rc1
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.27.0
       soroban_tools_ref: v20.1.0
@@ -60,7 +60,7 @@ jobs:
       arch: arm64
       tag: testing-arm64
       xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      core_ref: v20.2.0rc1
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.27.0

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-latest:
 build-testing:
 	$(MAKE) build TAG=testing \
 		XDR_REF=v20.0.2 \
-		CORE_REF=v20.1.0 \
+		CORE_REF=v20.2.0rc1 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.27.0 \
 		SOROBAN_RPC_REF=v20.1.0


### PR DESCRIPTION
Update testing manifest file to use the latest core_ref v20.2.0rc1 for arm and amd builds

FYI, @stellar/horizon-committers 