### PR TITLE
quickstart: Build Soroban RPC From New soroban-rpc Repo

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -34,6 +34,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
+      go_ref: horizon-v2.28.3
       soroban_rpc_ref: v20.1.0
       test_matrix: |
         {

--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -56,7 +56,6 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_cli_ref: v20.1.0
       soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -35,7 +35,7 @@ jobs:
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       test_matrix: |
         {
           "network": ["local"],
@@ -56,7 +56,8 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_cli_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -58,7 +58,6 @@ jobs:
       core_ref: v20.1.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_cli_ref: v20.1.0
       soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -35,7 +35,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       test_matrix: |
         {
           "network": ["pubnet", "local"],
@@ -58,7 +58,8 @@ jobs:
       core_ref: v20.1.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_cli_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -35,7 +35,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.2.0
       go_ref: horizon-v2.28.3
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v20.3.2
       test_matrix: |
         {
           "network": ["pubnet", "local"],
@@ -58,7 +58,7 @@ jobs:
       core_ref: v20.2.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.3
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v20.3.2
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -37,7 +37,7 @@ jobs:
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       test_matrix: |
         {
           "network": ["testnet", "pubnet", "local"],
@@ -61,7 +61,8 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_tools_ref: v20.1.0
+      soroban_cli_ref: v20.1.0
+      soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -61,7 +61,6 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.0
-      soroban_cli_ref: v20.1.0
       soroban_rpc_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -37,7 +37,7 @@ jobs:
       core_ref: v20.2.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.3
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v20.3.2
       test_matrix: |
         {
           "network": ["testnet", "pubnet", "local"],
@@ -61,7 +61,7 @@ jobs:
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.3
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v20.3.2
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ on:
         description: 'Git ref for the stellar/rs-stellar-xdr repo'
         type: 'string'
         required: false  
-      soroban_tools_ref:
-        description: 'Git ref for the stellar/soroban-tools repo (soroban-rpc)'
+      soroban_rpc_ref:
+        description: 'Git ref for the stellar/soroban-rpc repo (soroban-rpc)'
         type: 'string'
         required: true
       soroban_rpc_build_runner_type:
@@ -66,7 +66,7 @@ on:
 env:
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
   GO_REPO_BRANCH: ${{ inputs.go_ref }}
-  SOROBAN_TOOLS_REPO_BRANCH: ${{ inputs.soroban_tools_ref }}
+  SOROBAN_RPC_REPO_BRANCH: ${{ inputs.soroban_rpc_ref }}
   CORE_REPO: ${{ inputs.core_repo }}
   CORE_REPO_REF: ${{ inputs.core_ref }}
   XDR_REPO_REF: ${{ inputs.xdr_ref }}
@@ -160,7 +160,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-soroban-rpc-${{ inputs.arch }}-${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
+        key: image-stellar-soroban-rpc-${{ inputs.arch }}-${{ env.SOROBAN_RPC_REPO_BRANCH }}
     - if: steps.cache.outputs.cache-hit != 'true' && inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       with:
@@ -175,7 +175,7 @@ jobs:
         -t stellar-soroban-rpc:${{ inputs.arch }} 
         -o type=docker,dest=/tmp/image 
         --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true 
-        https://github.com/stellar/soroban-tools.git#${{ env.SOROBAN_TOOLS_REPO_BRANCH }}
+        https://github.com/stellar/soroban-rpc.git#${{ env.SOROBAN_RPC_REPO_BRANCH }}
     - name: Upload Stellar-Soroban-Rpc Image
       uses: actions/upload-artifact@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-latest:
 		CORE_REF=v20.2.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.3 \
-		SOROBAN_RPC_REF=v20.3.0
+		SOROBAN_RPC_REF=v20.3.2
 
 build-testing:
 	$(MAKE) build TAG=testing \
@@ -35,7 +35,7 @@ build-testing:
 		CORE_REF=v20.2.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.3 \
-		SOROBAN_RPC_REF=v20.3.0
+		SOROBAN_RPC_REF=v20.3.2
 
 build-future:
 	$(MAKE) build TAG=future \

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ build-deps-friendbot:
 	docker build -t stellar-friendbot:$(FRIENDBOT_REF) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(FRIENDBOT_REF)
 
 build-deps-soroban-rpc:
-	docker build -t stellar-soroban-rpc:$(SOROBAN_RPC_REF) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-tools.git#$(SOROBAN_RPC_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+	docker build -t stellar-soroban-rpc:$(SOROBAN_RPC_REF) -f cmd/soroban-rpc/docker/Dockerfile --target build https://github.com/stellar/soroban-rpc.git#$(SOROBAN_RPC_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image uses the following software:
 - [stellar-core](https://github.com/stellar/stellar-core)
 - [horizon](https://github.com/stellar/go/tree/master/services/horizon)
 - [friendbot](https://github.com/stellar/go/tree/master/services/friendbot)
-- [soroban-rpc](https://github.com/stellar/soroban-tools/tree/main/cmd/soroban-rpc)
+- [soroban-rpc](https://github.com/stellar/soroban-rpc/tree/main/cmd/soroban-rpc)
 - Supervisord is used from managing the processes of the services above
 
 ## Usage

--- a/scripts/soroban_repo_to_horizon_repo.sh
+++ b/scripts/soroban_repo_to_horizon_repo.sh
@@ -16,9 +16,9 @@ fi
 
 GO_MONOREPO=github.com/stellar/go
 SOROBAN_BRANCH=$1
-SOROBAN_REPO_GOMOD=https://raw.githubusercontent.com/stellar/soroban-tools/${SOROBAN_BRANCH}/go.mod
+SOROBAN_REPO_GOMOD=https://raw.githubusercontent.com/stellar/soroban-rpc/${SOROBAN_BRANCH}/go.mod
 
-# find the short commit from the soroban-tools repository.
+# find the short commit from the soroban-rpc repository.
 SHORT_COMMIT=$(curl -s ${SOROBAN_REPO_GOMOD} -o - | grep "${GO_MONOREPO} " | cut -d- -f3)
 
 # find the long commit from the actual go repository using the short commit.


### PR DESCRIPTION
Part of [CLI/RPC repo split](https://github.com/stellar/soroban-tools/issues/1171). We should build from `soroban-rpc` now.