### PR TITLE
Fix image status posts on builds

### DIFF
--- a/.github/actions/push/action.yml
+++ b/.github/actions/push/action.yml
@@ -69,7 +69,6 @@ runs:
             repo: context.repo.repo,
             sha: '${{ inputs.head_sha }}',
             state: 'success',
-            context: `${context.workflow} (${{ inputs.arch }})`,
+            context: `Image ${{ inputs.image }}`,
             target_url: '${{ env.IMAGE_URL }}',
-            description: '${{ inputs.image }}',
           });


### PR DESCRIPTION
### What
Change the name of the commit statuses that get manually posted after the image is pushed to include the image name.

### Why
I recently merged the image workflows together, and that resulted in the build pushing overlapping commit statuses that share the same context. What that means is that instead of seeing commit statuses for latest, testing, and future, we see just one, whichever was last as they are overwriting each other.