### PR TITLE
fix: increase postgres max_connections to 150

### DIFF
--- a/common/postgresql/etc/postgresql.conf
+++ b/common/postgresql/etc/postgresql.conf
@@ -50,7 +50,7 @@ ident_file = '/opt/stellar/postgresql/etc/pg_ident.conf'
 
 listen_addresses = '*'
 port = 5432				# (change requires restart)
-max_connections = 100			# (change requires restart)
+max_connections = 150			# (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3	# (change requires restart)


### PR DESCRIPTION
Ran into issues with too many connections on my linux destop with 128 threads. This seemed to be the magic number.

It would be nice to have a way to override this at runtime, but for now this should be good enough.