### PR TITLE
Update latest target to stable core v20.2.0

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -54,7 +54,7 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: arm64
       tag: ${{ inputs.tag-prefix }}latest-arm64
-      xdr_ref: v20.1.2
+      xdr_ref: v20.1.0
       core_ref: v20.2.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.1

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -32,10 +32,10 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: amd64
       tag: ${{ inputs.tag-prefix }}latest-amd64
-      xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      xdr_ref: v20.1.0
+      core_ref: v20.2.0
       go_ref: horizon-v2.28.1
-      soroban_tools_ref: v20.1.0
+      soroban_tools_ref: v20.3.0
       test_matrix: |
         {
           "network": ["pubnet", "local"],
@@ -54,11 +54,11 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: arm64
       tag: ${{ inputs.tag-prefix }}latest-arm64
-      xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      xdr_ref: v20.1.2
+      core_ref: v20.2.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.1
-      soroban_tools_ref: v20.1.0
+      soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -34,7 +34,7 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}testing-amd64
       xdr_ref: v20.1.0
-      core_ref: v20.2.0rc3
+      core_ref: v20.2.0
       core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.3.0
@@ -57,7 +57,7 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}testing-arm64
       xdr_ref: v20.1.0
-      core_ref: v20.2.0rc3
+      core_ref: v20.2.0
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.1

--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ console:
 
 build-latest:
 	$(MAKE) build TAG=latest \
-		XDR_REF=v20.0.2 \
-		CORE_REF=v20.1.0 \
+		XDR_REF=v20.1.0 \
+		CORE_REF=v20.2.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.1 \
-		SOROBAN_RPC_REF=v20.1.0
+		SOROBAN_RPC_REF=v20.3.0
 
 build-testing:
 	$(MAKE) build TAG=testing \
 		XDR_REF=v20.1.0 \
-		CORE_REF=v20.2.0rc3 \
+		CORE_REF=v20.2.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.1 \
 		SOROBAN_RPC_REF=v20.3.0


### PR DESCRIPTION
Update the latest target for quickstart build with stable core v20.2.0.
Also updated xdr and rpc ref for latest build.