### PR TITLE
Rollback to horizon version 2.28.1

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -34,7 +34,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.1.0
       test_matrix: |
         {
@@ -55,7 +55,7 @@ jobs:
       core_ref: v20.1.0
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -34,7 +34,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}latest-amd64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.1.0
       test_matrix: |
         {
@@ -57,7 +57,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -36,7 +36,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.2.0rc3
       core_supports_enable_soroban_diagnostic_events: "true"
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.3.0
       test_matrix: |
         {
@@ -60,7 +60,7 @@ jobs:
       core_ref: v20.2.0rc3
       core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.2
+      go_ref: horizon-v2.28.1
       soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-latest:
 		XDR_REF=v20.0.2 \
 		CORE_REF=v20.1.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
-		HORIZON_REF=horizon-v2.28.2 \
+		HORIZON_REF=horizon-v2.28.1 \
 		SOROBAN_RPC_REF=v20.1.0
 
 build-testing:
@@ -34,7 +34,7 @@ build-testing:
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.2.0rc3 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
-		HORIZON_REF=horizon-v2.28.2 \
+		HORIZON_REF=horizon-v2.28.1 \
 		SOROBAN_RPC_REF=v20.3.0
 
 build-future:
@@ -42,7 +42,7 @@ build-future:
 		XDR_REF=v20.0.2 \
 		CORE_REF=v20.1.0 \
 		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
-		HORIZON_REF=horizon-v2.28.2 \
+		HORIZON_REF=horizon-v2.28.1 \
 		SOROBAN_RPC_REF=v20.1.0
 
 build:


### PR DESCRIPTION
Rolling back to Horizon v2.28.1 because of a [regression](https://github.com/stellar/go/pull/5207) in v2.82.2.