### PR TITLE
Update `contractDataKeySizeBytes` for unlimited.json

### DIFF
--- a/local/core/etc/config-settings/unlimited.json
+++ b/local/core/etc/config-settings/unlimited.json
@@ -287,7 +287,7 @@
           ]
         },
         {
-            "contract_data_key_size_bytes": 300
+            "contract_data_key_size_bytes": 4294967295
         },
         {
             "contract_data_entry_size_bytes": 4294967295


### PR DESCRIPTION
This is a value I'd like to be able to test as an unlimited size along with the rest of the bytes related values