### PR TITLE
Remove CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS config

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -33,7 +33,6 @@ jobs:
       tag: ${{ inputs.tag-prefix }}future-amd64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
-      core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.3
       soroban_tools_ref: v20.1.0
       test_matrix: |
@@ -56,7 +55,6 @@ jobs:
       tag: ${{ inputs.tag-prefix }}future-arm64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
-      core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.3
       soroban_tools_ref: v20.1.0

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -35,7 +35,6 @@ jobs:
       tag: ${{ inputs.tag-prefix }}testing-amd64
       xdr_ref: v20.1.0
       core_ref: v20.3.0rc2
-      core_supports_enable_soroban_diagnostic_events: "true"
       go_ref: horizon-v2.28.3
       soroban_tools_ref: v20.3.0
       test_matrix: |
@@ -58,7 +57,6 @@ jobs:
       tag: ${{ inputs.tag-prefix }}testing-arm64
       xdr_ref: v20.1.0
       core_ref: v20.3.0rc2
-      core_supports_enable_soroban_diagnostic_events: "true"
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.28.3
       soroban_tools_ref: v20.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ on:
         description: 'CONFIGURE_FLAGS used when building stellar-core'
         type: 'string'
         default: '--disable-tests'
-      core_supports_enable_soroban_diagnostic_events:
-        description: 'Indicator whether stellar-core supports the ENABLE_SOROBAN_DIAGNOSTIC_EVENTS config'
-        type: 'string'
-        default: 'false'
       core_build_runner_type:
         description: 'The GitHub Runner instance type to build stellar-core on'
         type: 'string'
@@ -288,7 +284,6 @@ jobs:
         --build-arg HORIZON_IMAGE_REF=stellar-horizon:${{ inputs.arch }}
         --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:${{ inputs.arch }}
         --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:${{ inputs.arch }}
-        --build-arg CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=${{ inputs.core_supports_enable_soroban_diagnostic_events }}
     - name: Save Quickstart Image
       run: docker save $IMAGE -o /tmp/image
     - name: Upload Quickstart Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,6 @@ ADD pubnet /opt/stellar-default/pubnet
 ADD testnet /opt/stellar-default/testnet
 ADD futurenet /opt/stellar-default/futurenet
 
-ARG CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS
-ENV CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS $CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS
-
 ADD start /
 RUN ["chmod", "+x", "start"]
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ XDR_REF?=main
 CORE_REPO?=https://github.com/stellar/stellar-core.git
 CORE_REF?=master
 CORE_CONFIGURE_FLAGS?=--disable-tests
-CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS?=false
 SOROBAN_RPC_REF?=main
 HORIZON_REF?=$(shell ./scripts/soroban_repo_to_horizon_repo.sh $(SOROBAN_RPC_REF))
 FRIENDBOT_REF?=$(HORIZON_REF)
@@ -25,7 +24,6 @@ build-latest:
 	$(MAKE) build TAG=latest \
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.2.0 \
-		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.3 \
 		SOROBAN_RPC_REF=v20.3.0
 
@@ -33,7 +31,6 @@ build-testing:
 	$(MAKE) build TAG=testing \
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.3.0rc2 \
-		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.3 \
 		SOROBAN_RPC_REF=v20.3.0
 
@@ -41,7 +38,6 @@ build-future:
 	$(MAKE) build TAG=future \
 		XDR_REF=v20.0.2 \
 		CORE_REF=v20.1.0 \
-		CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=true \
 		HORIZON_REF=horizon-v2.28.3 \
 		SOROBAN_RPC_REF=v20.1.0
 
@@ -54,7 +50,6 @@ build:
 	  --build-arg HORIZON_IMAGE_REF=stellar-horizon:$(HORIZON_REF) \
 	  --build-arg FRIENDBOT_IMAGE_REF=stellar-friendbot:$(FRIENDBOT_REF) \
 	  --build-arg SOROBAN_RPC_IMAGE_REF=stellar-soroban-rpc:$(SOROBAN_RPC_REF) \
-	  --build-arg CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=$(CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS)
 
 build-deps: build-deps-xdr build-deps-core build-deps-horizon build-deps-friendbot build-deps-soroban-rpc
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ built with.
 build with. Typically include `--disable-tests`, and to enable the next protocol
 version that is still in development, add
 `--enable-next-protocol-version-unsafe-for-production`.
-- `CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS`: Flag for whether enabling Soroban diagnostic events is supported. Default `false`.
 - `HORIZON_REF`: The git reference of stellar-horizon to build.
 - `FRIENDBOT_REF`: The git reference of stellar-friendbot to build.
 - `SOROBAN_RPC_REF`: The git reference of soroban-rpc to build.


### PR DESCRIPTION
### What
Remove `CORE_SUPPORTS_ENABLE_SOROBAN_DIAGNOSTIC_EVENTS` config and related params.

### Why
It's no longer needed. All versions of core released in all the variants of the quickstart image support `ENABLE_SOROBAN_DIAGNOSTIC_EVENTS`.