### PR TITLE
Bump go version to 1.22

### DIFF
--- a/Dockerfile.horizon
+++ b/Dockerfile.horizon
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS builder
+FROM golang:1.22 AS builder
 
 ARG REF
 WORKDIR /go/src/github.com/stellar/go


### PR DESCRIPTION

Bump go version to 1.22 for Horizon
https://github.com/stellar/go/issues/5230