### PR TITLE
bump horizon refs to 2.29.0

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -33,7 +33,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}future-amd64
       xdr_ref: v20.0.2
       core_ref: v20.1.0
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.1.0
       test_matrix: |
         {
@@ -56,7 +56,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -34,7 +34,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}latest-amd64
       xdr_ref: v20.1.0
       core_ref: v20.3.0
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.3.0
       test_matrix: |
         {
@@ -57,7 +57,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.3.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -35,7 +35,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}testing-amd64
       xdr_ref: v20.1.0
       core_ref: v20.3.0
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.3.0
       test_matrix: |
         {
@@ -58,7 +58,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.3.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.28.3
+      go_ref: horizon-v2.29.0
       soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/Makefile
+++ b/Makefile
@@ -24,21 +24,21 @@ build-latest:
 	$(MAKE) build TAG=latest \
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.3.0 \
-		HORIZON_REF=horizon-v2.28.3 \
+		HORIZON_REF=horizon-v2.29.0 \
 		SOROBAN_RPC_REF=v20.3.0
 
 build-testing:
 	$(MAKE) build TAG=testing \
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.3.0 \
-		HORIZON_REF=horizon-v2.28.3 \
+		HORIZON_REF=horizon-v2.29.0 \
 		SOROBAN_RPC_REF=v20.3.0
 
 build-future:
 	$(MAKE) build TAG=future \
 		XDR_REF=v20.0.2 \
 		CORE_REF=v20.1.0 \
-		HORIZON_REF=horizon-v2.28.3 \
+		HORIZON_REF=horizon-v2.29.0 \
 		SOROBAN_RPC_REF=v20.1.0
 
 build:


### PR DESCRIPTION
update image build variants to use latest horizon release 2.29.0