### PR TITLE
Update stale job to v9

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           debug-only: false
           days-before-stale: 30


### PR DESCRIPTION
### What
Update the stale CI job to v9.

### Why
So that when it closes issues, they will be marked as closed and not completed, rather than closed and completed as it does today with v4.