### PR TITLE
Fix flakey build

### DIFF
--- a/test_horizon_core_up.go
+++ b/test_horizon_core_up.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -19,7 +20,7 @@ func main() {
 
 	for {
 		time.Sleep(5 * time.Second)
-		logLine("Waiting for Horizon's stellar-core to start reporting")
+		logLine(fmt.Sprint("Waiting for Horizon's stellar-core to start reporting", time.Since(startTime)))
 
 		// if time.Since(startTime) > timeout {
 		// 	logLine("Timeout")

--- a/test_horizon_core_up.go
+++ b/test_horizon_core_up.go
@@ -42,7 +42,7 @@ func main() {
 		}
 
 		if root.CoreSupportedProtocolVersion > 0 {
-			logLine("Horizon is communicating with stellar-core!")
+			logLine(fmt.Sprintf("Horizon is communicating with stellar-core!", time.Since(startTime)))
 			os.Exit(0)
 		}
 	}

--- a/test_horizon_core_up.go
+++ b/test_horizon_core_up.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"time"
 )
 
-// const timeout = 6 * time.Minute
+const timeout = 10 * time.Minute
 
 type Root struct {
 	CoreSupportedProtocolVersion int32 `json:"core_supported_protocol_version"`
@@ -20,12 +19,12 @@ func main() {
 
 	for {
 		time.Sleep(5 * time.Second)
-		logLine(fmt.Sprint("Waiting for Horizon's stellar-core to start reporting", time.Since(startTime)))
+		logLine("Waiting for Horizon's stellar-core to start reporting")
 
-		// if time.Since(startTime) > timeout {
-		// 	logLine("Timeout")
-		// 	os.Exit(-1)
-		// }
+		if time.Since(startTime) > timeout {
+			logLine("Timeout")
+			os.Exit(-1)
+		}
 
 		resp, err := http.Get("http://localhost:8000")
 		if err != nil {
@@ -42,7 +41,7 @@ func main() {
 		}
 
 		if root.CoreSupportedProtocolVersion > 0 {
-			logLine(fmt.Sprintf("Horizon is communicating with stellar-core!", time.Since(startTime)))
+			logLine("Horizon is communicating with stellar-core!")
 			os.Exit(0)
 		}
 	}

--- a/test_horizon_core_up.go
+++ b/test_horizon_core_up.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const timeout = 6 * time.Minute
+// const timeout = 6 * time.Minute
 
 type Root struct {
 	CoreSupportedProtocolVersion int32 `json:"core_supported_protocol_version"`
@@ -21,10 +21,10 @@ func main() {
 		time.Sleep(5 * time.Second)
 		logLine("Waiting for Horizon's stellar-core to start reporting")
 
-		if time.Since(startTime) > timeout {
-			logLine("Timeout")
-			os.Exit(-1)
-		}
+		// if time.Since(startTime) > timeout {
+		// 	logLine("Timeout")
+		// 	os.Exit(-1)
+		// }
 
 		resp, err := http.Get("http://localhost:8000")
 		if err != nil {


### PR DESCRIPTION
### What
Set timeout of horizon core up test to 10 mins.

### Why
The timeout of the horizon core up test is currently set to 6 mins. It seems to have recently been failing a few times around the 6 min 15 sec mark. The timeout is there so tests don't run extraordinarily long due to a bug, so 10 mins seems appropriate.