### PR TITLE
Bump horizon to 2.30.0

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -34,7 +34,7 @@ jobs:
       protocol_version_default: 20
       xdr_ref: v20.0.2
       core_ref: v20.1.0
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.1.0
       test_matrix: |
         {
@@ -58,7 +58,7 @@ jobs:
       xdr_ref: v20.0.2
       core_ref: v20.1.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.1.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -35,7 +35,7 @@ jobs:
       protocol_version_default: 20
       xdr_ref: v20.1.0
       core_ref: v20.4.0
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.3.0
       test_matrix: |
         {
@@ -59,7 +59,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.4.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -36,7 +36,7 @@ jobs:
       protocol_version_default: 20
       xdr_ref: v20.1.0
       core_ref: v20.4.0
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.3.0
       test_matrix: |
         {
@@ -60,7 +60,7 @@ jobs:
       xdr_ref: v20.1.0
       core_ref: v20.4.0
       core_build_runner_type: ubuntu-latest-16-cores
-      go_ref: horizon-v2.29.0
+      go_ref: horizon-v2.30.0
       soroban_tools_ref: v20.3.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-latest:
 		PROTOCOL_VERSION_DEFAULT=20 \
 		XDR_REF=v20.1.0 \
 		CORE_REF=v20.4.0 \
-		HORIZON_REF=horizon-v2.29.0 \
+		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v20.3.0
 
 build-testing:
@@ -34,7 +34,7 @@ build-testing:
 	    PROTOCOL_VERSION_DEFAULT=20 \
 		XDR_REF=v21.0.0 \
 		CORE_REF=v21.0.0rc1 \
-		HORIZON_REF=horizon-v2.29.0 \
+		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v20.3.0
 
 build-future:
@@ -42,7 +42,7 @@ build-future:
 		PROTOCOL_VERSION_DEFAULT=20 \
 		XDR_REF=v20.0.2 \
 		CORE_REF=v20.1.0 \
-		HORIZON_REF=horizon-v2.29.0 \
+		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v20.1.0
 
 build:


### PR DESCRIPTION
Bump horizon to [v2.30.0](https://github.com/stellar/go/releases/tag/horizon-v2.30.0)