### PR TITLE
Update testnet and futurenet image variants to latest xdr, core and rpc release

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -32,7 +32,7 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}future-amd64
       protocol_version_default: 20
-      xdr_ref: v21.1
+      xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1
@@ -55,7 +55,7 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}future-arm64
       protocol_version_default: 20
-      xdr_ref: v21.1
+      xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0

--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -32,10 +32,10 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}future-amd64
       protocol_version_default: 20
-      xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      xdr_ref: v21.1
+      core_ref: v21.0.0rc1
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.0
+      soroban_rpc_ref: v21.0.1
       test_matrix: |
         {
           "network": ["local"],
@@ -55,11 +55,11 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}future-arm64
       protocol_version_default: 20
-      xdr_ref: v20.0.2
-      core_ref: v20.1.0
+      xdr_ref: v21.1
+      core_ref: v21.0.0rc1
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.0
+      soroban_rpc_ref: v21.0.1
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -34,7 +34,7 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}testing-amd64
       protocol_version_default: 21
-      xdr_ref: v21.1
+      xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1
@@ -57,7 +57,7 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}testing-arm64
       protocol_version_default: 21
-      xdr_ref: v21.1
+      xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -34,10 +34,10 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}testing-amd64
       protocol_version_default: 21
-      xdr_ref: v21.0.0
+      xdr_ref: v21.1
       core_ref: v21.0.0rc1
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.0
+      soroban_rpc_ref: v21.0.1
       test_matrix: |
         {
           "network": ["testnet", "pubnet", "local"],
@@ -57,11 +57,11 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}testing-arm64
       protocol_version_default: 21
-      xdr_ref: v21.0.0
+      xdr_ref: v21.1
       core_ref: v21.0.0rc1
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.0
+      soroban_rpc_ref: v21.0.1
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,18 @@ build-latest:
 build-testing:
 	$(MAKE) build TAG=testing \
 	    PROTOCOL_VERSION_DEFAULT=21 \
-		XDR_REF=v21.0.0 \
+		XDR_REF=v21.1 \
 		CORE_REF=v21.0.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v21.0.0
+		SOROBAN_RPC_REF=v21.0.1
 
 build-future:
 	$(MAKE) build TAG=future \
 		PROTOCOL_VERSION_DEFAULT=20 \
-		XDR_REF=v20.0.2 \
-		CORE_REF=v20.1.0 \
+		XDR_REF=v21.1 \
+		CORE_REF=v21.0.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v21.0.0
+		SOROBAN_RPC_REF=v21.0.1
 
 build:
 	$(MAKE) -j 4 build-deps

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-latest:
 build-testing:
 	$(MAKE) build TAG=testing \
 	    PROTOCOL_VERSION_DEFAULT=21 \
-		XDR_REF=v21.1 \
+		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v21.0.1
@@ -40,7 +40,7 @@ build-testing:
 build-future:
 	$(MAKE) build TAG=future \
 		PROTOCOL_VERSION_DEFAULT=20 \
-		XDR_REF=v21.1 \
+		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v21.0.1


### PR DESCRIPTION
### What?
Update testnet and futurenet image variants to latest xdr, core and rpc release.

### Why?
This is the last part of our release process. We will be asking ecosystem to test in Futurenet and Testnet so need to have the latest available in quickstart. 