### PR TITLE
Reenable future builds

### DIFF
--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -61,16 +61,12 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
 
-  # TODO: Reenable the future build when the version of soroban-rpc used in the
-  # future build supports the stellar-core ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION
-  # config, and the time has come for a new preview release.
-  #
-  # future:
-  #   needs: [setup]
-  #   uses: ./.github/workflows/build-future.yml
-  #   secrets:
-  #     DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  #     DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  #   with:
-  #     sha: ${{ github.event.pull_request.head.sha || github.sha }}
-  #     tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
+  future:
+    needs: [setup]
+    uses: ./.github/workflows/build-future.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    with:
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      tag-prefix: ${{ needs.setup.outputs.tag-prefix }}


### PR DESCRIPTION
### What
Re-enable future image builds.

### Why
Horizon and the RPC specified in the future builds now supports setting `ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION` on the stellar-core they run.

