### PR TITLE
Set the default protocol version to 21 for future

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -31,7 +31,7 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: amd64
       tag: ${{ inputs.tag-prefix }}future-amd64
-      protocol_version_default: 20
+      protocol_version_default: 21
       xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       go_ref: horizon-v2.30.0
@@ -54,7 +54,7 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: arm64
       tag: ${{ inputs.tag-prefix }}future-arm64
-      protocol_version_default: 20
+      protocol_version_default: 21
       xdr_ref: v21.0.1
       core_ref: v21.0.0rc1
       core_build_runner_type: ubuntu-latest-16-cores

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build-testing:
 
 build-future:
 	$(MAKE) build TAG=future \
-		PROTOCOL_VERSION_DEFAULT=20 \
+		PROTOCOL_VERSION_DEFAULT=21 \
 		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \


### PR DESCRIPTION
### What
Set the default protocol version to 21 for future

### Why
Future builds have versions of core, rpc, and horizon that should support protocol 21, so the local should default to running that protocol version. The only reason to have a lower version is if all the software doesn't yet support the latest because then startup of a local will fail with the default protocol version.