### PR TITLE
Default to cores max protocol version in local mode when no default specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ __PHONY__: run logs build build-deps build-deps-core build-deps-horizon build-de
 
 REVISION=$(shell git -c core.abbrev=no describe --always --exclude='*' --long --dirty)
 TAG?=dev
-PROTOCOL_VERSION_DEFAULT?=20
+PROTOCOL_VERSION_DEFAULT?=
 XDR_REPO?=https://github.com/stellar/rs-stellar-xdr.git
 XDR_REF?=main
 CORE_REPO?=https://github.com/stellar/stellar-core.git

--- a/start
+++ b/start
@@ -512,6 +512,11 @@ function upgrade_local() {
   # Wait for server
   while ! echo "Stellar-core http server listening!" | nc localhost 11626 &> /dev/null; do sleep 1; done
 
+  # Default to latest version supported by core if no default or explicit version was set
+  if [ -z "$PROTOCOL_VERSION" ]; then
+    export PROTOCOL_VERSION=`curl -s http://localhost:11626/info | jq -r '.info.protocol_version'`
+  fi
+
   if [ ".$PROTOCOL_VERSION" == ".none" ] ; then
     return
   fi


### PR DESCRIPTION
### What
Default to cores max protocol version in local mode when no default specified.

### Why
In #594 I removed the automatic default and replaced it with an explicit default because nearing protocol releases we have versions of software being updated in quickstart without coordination, which is good, and having local always startup a network based on core's max supported protocol version meant that in some cases it would start networks that the image as a whole was not ready to run.

When I removed the automatic default I made it so that an explicit default had to be set. That requirement was somewhat unnecessary. For most uses of quickstart simply using what core thinks the version should be is fine, and it's those edge cases where we need it specified.

I'd like to keep it as so so that in other uses of quickstart, like the system-tests, don't need to also coordinate the default version in their default configuration and can rely on quickstart figuring it out for the common case.

Related:
- https://github.com/stellar/system-test/pull/93