### PR TITLE
Update quickstart to use stable Core v21.

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -33,7 +33,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}future-amd64
       protocol_version_default: 21
       xdr_ref: v21.0.1
-      core_ref: v21.0.0rc2
+      core_ref: v21.0.0
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1
       test_matrix: |
@@ -56,7 +56,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}future-arm64
       protocol_version_default: 21
       xdr_ref: v21.0.1
-      core_ref: v21.0.0rc2
+      core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1

--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -35,7 +35,7 @@ jobs:
       xdr_ref: v21.0.1
       core_ref: v21.0.0
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       test_matrix: |
         {
           "network": ["local"],
@@ -59,7 +59,7 @@ jobs:
       core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -33,10 +33,10 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}latest-amd64
       protocol_version_default: 20
-      xdr_ref: v20.1.0
-      core_ref: v20.4.0
+      xdr_ref: v21.0.1
+      core_ref: v21.0.0
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v21.0.1
       test_matrix: |
         {
           "network": ["pubnet", "local"],
@@ -56,11 +56,11 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}latest-arm64
       protocol_version_default: 20
-      xdr_ref: v20.1.0
-      core_ref: v20.4.0
+      xdr_ref: v21.0.1
+      core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v20.3.0
+      soroban_rpc_ref: v21.0.1
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -36,7 +36,7 @@ jobs:
       xdr_ref: v21.0.1
       core_ref: v21.0.0
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       test_matrix: |
         {
           "network": ["pubnet", "local"],
@@ -60,7 +60,7 @@ jobs:
       core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -35,7 +35,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}testing-amd64
       protocol_version_default: 21
       xdr_ref: v21.0.1
-      core_ref: v21.0.0rc2
+      core_ref: v21.0.0
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1
       test_matrix: |
@@ -58,7 +58,7 @@ jobs:
       tag: ${{ inputs.tag-prefix }}testing-arm64
       protocol_version_default: 21
       xdr_ref: v21.0.1
-      core_ref: v21.0.0rc2
+      core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.0.1

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -37,7 +37,7 @@ jobs:
       xdr_ref: v21.0.1
       core_ref: v21.0.0
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       test_matrix: |
         {
           "network": ["testnet", "pubnet", "local"],
@@ -61,7 +61,7 @@ jobs:
       core_ref: v21.0.0
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
-      soroban_rpc_ref: v21.0.1
+      soroban_rpc_ref: v21.2.0
       soroban_rpc_build_runner_type: ubuntu-latest-16-cores
       test_matrix: |
         {

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-latest:
 		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v21.0.1
+		SOROBAN_RPC_REF=v21.2.0
 
 build-testing:
 	$(MAKE) build TAG=testing \
@@ -35,7 +35,7 @@ build-testing:
 		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v21.0.1
+		SOROBAN_RPC_REF=v21.2.0
 
 build-future:
 	$(MAKE) build TAG=future \
@@ -43,7 +43,7 @@ build-future:
 		XDR_REF=v21.0.1 \
 		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v21.0.1
+		SOROBAN_RPC_REF=v21.2.0
 
 build:
 	$(MAKE) -j 4 build-deps

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,16 @@ console:
 build-latest:
 	$(MAKE) build TAG=latest \
 		PROTOCOL_VERSION_DEFAULT=20 \
-		XDR_REF=v20.1.0 \
-		CORE_REF=v20.4.0 \
+		XDR_REF=v21.0.1 \
+		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
-		SOROBAN_RPC_REF=v20.3.0
+		SOROBAN_RPC_REF=v21.0.1
 
 build-testing:
 	$(MAKE) build TAG=testing \
 	    PROTOCOL_VERSION_DEFAULT=21 \
 		XDR_REF=v21.0.1 \
-		CORE_REF=v21.0.0rc2 \
+		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v21.0.1
 
@@ -41,7 +41,7 @@ build-future:
 	$(MAKE) build TAG=future \
 		PROTOCOL_VERSION_DEFAULT=21 \
 		XDR_REF=v21.0.1 \
-		CORE_REF=v21.0.0rc2 \
+		CORE_REF=v21.0.0 \
 		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v21.0.1
 


### PR DESCRIPTION
Also update XDR/RPC references for the 'latest' build in order to have consistent v21 stack.