### PR TITLE
Update core and rust xdr refs to v21.1.0 for testing targets

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -34,8 +34,8 @@ jobs:
       arch: amd64
       tag: ${{ inputs.tag-prefix }}testing-amd64
       protocol_version_default: 21
-      xdr_ref: v21.0.1
-      core_ref: v21.0.0
+      xdr_ref: v21.1.0
+      core_ref: v21.1.0rc1
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.2.0
       test_matrix: |
@@ -57,8 +57,8 @@ jobs:
       arch: arm64
       tag: ${{ inputs.tag-prefix }}testing-arm64
       protocol_version_default: 21
-      xdr_ref: v21.0.1
-      core_ref: v21.0.0
+      xdr_ref: v21.1.0
+      core_ref: v21.1.0rc1
       core_build_runner_type: ubuntu-latest-16-cores
       go_ref: horizon-v2.30.0
       soroban_rpc_ref: v21.2.0

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ build-latest:
 build-testing:
 	$(MAKE) build TAG=testing \
 	    PROTOCOL_VERSION_DEFAULT=21 \
-		XDR_REF=v21.0.1 \
-		CORE_REF=v21.0.0 \
+		XDR_REF=v21.1.0 \
+		CORE_REF=v21.1.0rc1 \
 		HORIZON_REF=horizon-v2.30.0 \
 		SOROBAN_RPC_REF=v21.2.0
 


### PR DESCRIPTION
### What: 
Update core and rust xdr refs to v21.1.0 for testing targets