### PR TITLE
'--enable core --local' only runs core, no ancillary services

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,7 +371,7 @@ jobs:
         go run test_horizon_ingesting.go
         curl http://localhost:8000
     - name: Run friendbot test
-      if: ${{ matrix.network == 'local' }}
+      if: ${{ matrix.horizon && matrix.network == 'local' }}
       run: |
         docker logs stellar -f &
         echo "supervisorctl tail -f friendbot" | docker exec -i stellar sh &

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ In local network mode, you can optionally pass:
    - `testnet` sets limits to match those used on testnet (the default quickstart configuration)
    - `unlimited` sets limits to the maximum resources that can be configured
 
+- `--enable {core, horizon, rpc}` to further select which services are started in the quickstart container. Since using a 'local' network, the core service will be started regardless as it runs the 'local' network, and these additional permutations of `--enable` are applicable:
+   - not specified, the default behavior will be to run core, horizon, friendbot, rpc. 
+   - `core` only runs the stellar core and an associated archive server.
+   - `core,horizon` runs core, horizon, friendbot
+   - `horizon` runs core, horizon, friendbot  
+   - `rpc` runs core, horizon, friendbot, rpc. 
+
 The network passphrase of the network defaults to:
 ```
 Standalone Network ; February 2017
@@ -93,8 +100,6 @@ To run only select services, simply specify only those services. For example, to
 ```
 --enable rpc
 ```
-
-__Note: All services, and in addition friendbot, always run on a local network.__
 
 ### Faucet (Friendbot)
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,7 @@ In local network mode, you can optionally pass:
    - `testnet` sets limits to match those used on testnet (the default quickstart configuration)
    - `unlimited` sets limits to the maximum resources that can be configured
 
-- `--enable {core, horizon, rpc}` to further select which services are started in the quickstart container. Since using a 'local' network, the core service will be started regardless as it runs the 'local' network, and these additional permutations of `--enable` are applicable:
-   - not specified, the default behavior will be to run core, horizon, friendbot, rpc. 
-   - `core` only runs the stellar core and an associated archive server.
-   - `core,horizon` runs core, horizon, friendbot
-   - `horizon` runs core, horizon, friendbot  
-   - `rpc` runs core, horizon, friendbot, rpc. 
-
+__Note: The `--enable` options behaves differently in local network mode, see [Service Options](#service-otions) for more details.__
 The network passphrase of the network defaults to:
 ```
 Standalone Network ; February 2017
@@ -100,7 +94,7 @@ To run only select services, simply specify only those services. For example, to
 ```
 --enable rpc
 ```
-
+__Note: In `--local` mode the `core` service always runs no matter what options are passed, the `friendbot` faucet service runs whenever `horizon` is running, and `horizon` is run when `rpc` is requested so that friendbot is available.__
 ### Faucet (Friendbot)
 
 Stellar development/test networks use friendbot as a faucet for the native asset.

--- a/start
+++ b/start
@@ -539,7 +539,7 @@ function upgrade_local() {
   # Upgrade local network's soroban config to match testnet, unless the limits
   # have been configured with 'default', which will cause the limits to be left
   # in their default state.
-  if [ "$ENABLE_SOROBAN_RPC" == "true" ] && [ $PROTOCOL_VERSION -ge 20 ] && [ "$LIMITS" != "default" ]; then
+  if [ $PROTOCOL_VERSION -ge 20 ] && [ "$LIMITS" != "default" ]; then
     echo "upgrades: soroban config '$LIMITS' limits"
     # Generate txs for installing, deploying and executing the contract that
     # uploads a new config. Use the network root account to submit the txs.

--- a/start
+++ b/start
@@ -176,6 +176,16 @@ function process_args() {
     NETWORK="testnet"
   fi
 
+  if [[ ",$ENABLE," = *",core,"* ]]; then
+    ENABLE_CORE=true
+  fi
+  if [[ ",$ENABLE," = *",horizon,"* ]]; then
+    ENABLE_HORIZON=true
+  fi
+  if [[ ",$ENABLE," = *",rpc,"* ]]; then
+    ENABLE_SOROBAN_RPC=true
+  fi
+
   case "$NETWORK" in
   testnet)
     export NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
@@ -190,6 +200,9 @@ function process_args() {
     # h1570ry - we'll start a webserver connected to history directory later on
     export HISTORY_ARCHIVE_URLS="http://localhost:1570"
     ENABLE_CORE=true
+    if [[ "$ENABLE_SOROBAN_RPC" = "true" ]]; then
+      ENABLE_HORIZON=true
+    fi
     ;;
   futurenet)
     export NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
@@ -199,16 +212,6 @@ function process_args() {
     echo "Unknown network: '$NETWORK'" >&2
     exit 1
   esac
-
-  if [[ ",$ENABLE," = *",core,"* ]]; then
-    ENABLE_CORE=true
-  fi
-  if [[ ",$ENABLE," = *",horizon,"* ]]; then
-    ENABLE_HORIZON=true
-  fi
-  if [[ ",$ENABLE," = *",rpc,"* ]]; then
-    ENABLE_SOROBAN_RPC=true
-  fi
 
   if [ "$RANDOMIZE_NETWORK_PASSPHRASE" = "true" ]; then
     NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE} ; $(openssl rand -hex 32)"

--- a/start
+++ b/start
@@ -190,7 +190,6 @@ function process_args() {
     # h1570ry - we'll start a webserver connected to history directory later on
     export HISTORY_ARCHIVE_URLS="http://localhost:1570"
     ENABLE_CORE=true
-    ENABLE_HORIZON=true
     ;;
   futurenet)
     export NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
@@ -540,7 +539,7 @@ function upgrade_local() {
   # Upgrade local network's soroban config to match testnet, unless the limits
   # have been configured with 'default', which will cause the limits to be left
   # in their default state.
-  if [ $PROTOCOL_VERSION -ge 20 ] && [ "$LIMITS" != "default" ]; then
+  if [ "$ENABLE_SOROBAN_RPC" == "true" ] && [ $PROTOCOL_VERSION -ge 20 ] && [ "$LIMITS" != "default" ]; then
     echo "upgrades: soroban config '$LIMITS' limits"
     # Generate txs for installing, deploying and executing the contract that
     # uploads a new config. Use the network root account to submit the txs.
@@ -597,7 +596,9 @@ function upgrade_local() {
   # account to submit txs. while friend it is not dependent on the config
   # upgrade txs, it must not be started until the config upgrades are
   # complete otherwise the txs sequence numbers will conflict.
-  supervisorctl start friendbot
+  if [ "$ENABLE_HORIZON" == "true" ]; then
+      supervisorctl start friendbot
+  fi    
 }
 
 function start_optional_services() {


### PR DESCRIPTION
#### What Changed
when using `--local --enable core,,` do not start the horizon/friendbot service in container, only core service will be running. 

this removes prior default behavior, which started horizon and friendbot services automatically when `--local` was used.

#### Why

we are using quickstart for new end-to-end integration tests now, and noticed with `--enable core,,` if `--local` was used, quickstart would still start horizon/friendbot in container, here is reference of how the test uses these flags:

https://github.com/stellar/go/pull/5370/files#diff-1c787ef8e522ba695cb843ceef6c93e842a3cfc319085d6b78349a1c4ec201abR279

the testing environment only needs the local core validator/history archive server available which quickstart automates the provisioning of these services very conveniently(and reliably for latest versions) and allows the tests to avoid significant boilerplate code otherwise to spin up it's own local core/archive, however, with quickstart spinning up other services in the container, it's giving up some of the gains made in the test use case, since it is consuming more integration test host compute.