### PR TITLE
Tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stellar Quickstart Docker Image
 
-This docker image provides a simple way to run stellar-core and horizon locally for development and testing.
+This docker image provides a simple way to run all the components of a Stelar network locally for development and testing.
 
 **Looking for instructions for how to run stellar-core or horizon in production? Take a look at the docs [here](https://developers.stellar.org/docs/run-core-node/).**
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Stellar Quickstart Docker Image
 
-This docker image provides a simple way to run all the components of a Stelar network locally for development and testing.
+This docker image provides a simple way to run all the components of a Stellar network locally or in CI for development and testing.
 
-**Looking for instructions for how to run Stellar services in production?** Take a look at these docs for how to run each service in production:
-- [How to run Stellar Core in production](https://developers.stellar.org/docs/run-core-node/)
-- [How to run Horizon in production](https://developers.stellar.org/docs/data/horizon/admin-guide/overview)
-- [How to run RPC in production](https://developers.stellar.org/docs/data/rpc/admin-guide)
+> [!IMPORTANT]  
+> This docker image is intended for use in development, not production. See these docs for how to run Stellar services in production:
+> - [How to run Stellar Core in production](https://developers.stellar.org/docs/run-core-node/)
+> - [How to run Horizon in production](https://developers.stellar.org/docs/data/horizon/admin-guide/overview)
+> - [How to run RPC in production](https://developers.stellar.org/docs/data/rpc/admin-guide)
 
 This image provides a default, non-validating, ephemeral configuration that should work for most developers. By configuring a container using this image with a host-based volume (described below in the "Usage" section) an operator gains access to full configuration customization and persistence of data.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This docker image provides a simple way to run all the components of a Stelar network locally for development and testing.
 
-**Looking for instructions for how to run stellar-core or horizon in production? Take a look at the docs [here](https://developers.stellar.org/docs/run-core-node/).**
+**Looking for instructions for how to run Stellar services in production?** Take a look at these docs for how to run each service in production:
+- [How to run Stellar Core in production](https://developers.stellar.org/docs/run-core-node/)
+- [How to run Horizon in production](https://developers.stellar.org/docs/data/horizon/admin-guide/overview)
+- [How to run RPC in production](https://developers.stellar.org/docs/data/rpc/admin-guide)
 
 This image provides a default, non-validating, ephemeral configuration that should work for most developers. By configuring a container using this image with a host-based volume (described below in the "Usage" section) an operator gains access to full configuration customization and persistence of data.
 


### PR DESCRIPTION
### What
Tweak the language at the top of the README to broadly refer to running a Stellar network rather than specific tools and link to more docs for how to setup services in production rather than only cores docs. And emphasise the recommendation to not use in production.

#### Before


<img width="715" alt="Screenshot 2024-09-04 at 12 38 32 PM" src="https://github.com/user-attachments/assets/52cbb24c-33f3-46a3-a059-402de32d6fa3">

#### After
<img width="715" alt="Screenshot 2024-09-04 at 12 38 19 PM" src="https://github.com/user-attachments/assets/4cc91b4c-2d7a-443e-9f77-6f80d45f3827">

### Why
Over time the tools that the quickstart image run has changed. Also, anything we can do to continue to emphasise that quickstart is a development tool is worthwhile.