### PR TITLE
Bump latest to v22

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -32,7 +32,7 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: amd64
       tag: ${{ inputs.tag-prefix }}latest-amd64
-      protocol_version_default: 21
+      protocol_version_default: 22
       xdr_ref: v22.0.0
       core_ref: v22.0.0
       horizon_ref: horizon-v22.0.1
@@ -56,7 +56,7 @@ jobs:
       sha: ${{ inputs.sha }}
       arch: arm64
       tag: ${{ inputs.tag-prefix }}latest-arm64
-      protocol_version_default: 21
+      protocol_version_default: 22
       xdr_ref: v22.0.0
       core_ref: v22.0.0
       horizon_ref: horizon-v22.0.1

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ console:
 
 build-latest:
 	$(MAKE) build TAG=latest \
-		PROTOCOL_VERSION_DEFAULT=21 \
+		PROTOCOL_VERSION_DEFAULT=22 \
 		XDR_REF=v22.0.0 \
 		CORE_REF=v22.0.0 \
 		HORIZON_REF=horizon-v22.0.1 \


### PR DESCRIPTION
Pubnet has upgraded to v22, so this value can be bumped now.