### PR TITLE
troubleshoot the limits validation timing during start with local network

### DIFF
--- a/start
+++ b/start
@@ -60,15 +60,16 @@ function validate_before_start() {
   fi
 }
 
-function validate_after_copy_defaults() {
+function validate_limits() {
   if [ "$NETWORK" = "local" ] && [ "$LIMITS" != "default" ]; then
     local config_dir="$COREHOME/etc/config-settings/p$PROTOCOL_VERSION"
     local config_path="$config_dir/$LIMITS.json"
     if [ ! -f "$config_path" ]; then
       echo "--limits '$LIMITS' unknown: must be one of: default "$(ls $config_dir | sed 's/\.json//g')
-      exit 1
+      return false
     fi
   fi
+  return true
 }
 
 function start() {
@@ -91,7 +92,6 @@ function start() {
   echo "network root account id: $NETWORK_ROOT_ACCOUNT_ID"
 
   copy_defaults
-  validate_after_copy_defaults
   init_db
   init_stellar_core
   init_horizon
@@ -539,6 +539,11 @@ function upgrade_local() {
   if [ ".$PROTOCOL_VERSION" == ".none" ] ; then
     return
   fi
+
+  if [ ! validate_limits ] ; then
+    echo "!!!!! Unable to upgrade Soroban Config Settings. Stopping all services. !!!!!"
+    kill_supervisor
+  fi   
 
   # Upgrade local network's protocol version and base reserve to match pubnet/testnet
   if [ $PROTOCOL_VERSION -gt 0 ]; then


### PR DESCRIPTION
the 'limits' config file path validation when' local' network was referring to PROTOCOL_VERSION before `start` had a chance to fully qualify it when not explicitly set from env or param, i.e. it will then set PROTOCOL_VERSION based on current core runtime default version reported after process start.

resolves e2e test failures on stellar-rpc - https://github.com/stellar/stellar-rpc/actions/runs/12363207197/job/34504081784