### PR TITLE
Require PROTOCOL_VERSION_DEFAULT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ADD start /
 RUN ["chmod", "+x", "start"]
 
 ARG PROTOCOL_VERSION_DEFAULT
-RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "Docker build arg PROTOCOL_VERSION_DEFAULT required and not set" && false)
+RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "Image build arg PROTOCOL_VERSION_DEFAULT required and not set" && false)
 ENV PROTOCOL_VERSION_DEFAULT $PROTOCOL_VERSION_DEFAULT
 
 ENTRYPOINT ["/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ADD start /
 RUN ["chmod", "+x", "start"]
 
 ARG PROTOCOL_VERSION_DEFAULT
-RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "PROTOCOL_VERSION_DEFAULT  required and not set" && false)
+RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "PROTOCOL_VERSION_DEFAULT required and not set" && false)
 ENV PROTOCOL_VERSION_DEFAULT $PROTOCOL_VERSION_DEFAULT
 
 ENTRYPOINT ["/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ADD start /
 RUN ["chmod", "+x", "start"]
 
 ARG PROTOCOL_VERSION_DEFAULT
-RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "PROTOCOL_VERSION_DEFAULT required and not set" && false)
+RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "Docker build arg PROTOCOL_VERSION_DEFAULT required and not set" && false)
 ENV PROTOCOL_VERSION_DEFAULT $PROTOCOL_VERSION_DEFAULT
 
 ENTRYPOINT ["/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ADD start /
 RUN ["chmod", "+x", "start"]
 
 ARG PROTOCOL_VERSION_DEFAULT
+RUN test -n "$PROTOCOL_VERSION_DEFAULT" || (echo "PROTOCOL_VERSION_DEFAULT  required and not set" && false)
 ENV PROTOCOL_VERSION_DEFAULT $PROTOCOL_VERSION_DEFAULT
 
 ENTRYPOINT ["/start"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ __PHONY__: run logs build build-deps build-deps-core build-deps-horizon build-de
 
 REVISION=$(shell git -c core.abbrev=no describe --always --exclude='*' --long --dirty)
 TAG?=dev
-PROTOCOL_VERSION_DEFAULT?=
+PROTOCOL_VERSION_DEFAULT?=22
 XDR_REPO?=https://github.com/stellar/rs-stellar-xdr.git
 XDR_REF?=main
 CORE_REPO?=https://github.com/stellar/stellar-core.git

--- a/start
+++ b/start
@@ -531,11 +531,6 @@ function upgrade_local() {
   # Wait for server
   while ! echo "Stellar-core http server listening!" | nc localhost 11626 &> /dev/null; do sleep 1; done
 
-  # Default to latest version supported by core if no default or explicit version was set
-  if [ -z "$PROTOCOL_VERSION" ]; then
-    export PROTOCOL_VERSION=`curl -s http://localhost:11626/info | jq -r '.info.protocol_version'`
-  fi
-
   if [ ".$PROTOCOL_VERSION" == ".none" ] ; then
     return
   fi


### PR DESCRIPTION
### What
Error during image build if the `PROTOCOL_VERSION_DEFAULT` variable is not set.

### Why
Images won't reliably work unless the arg is set. The image does fall back to whatever core's max supported protocol version, but we moved away from that a while ago and missed removing that check. The reason we don't rely on that anymore is that core's max supported version is not representative of the entire images max supported version because the image runs multiple software and it's common for core to release a new version before other software.