### PR TITLE
Add stellar-cli method to run the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Stellar Quickstart Docker Image
 
+> [!TIP]  
+> Install the [`stellar-cli`] and start development containers running this image with:
+>
+> ```
+> stellar container start local
+> ```
+
+[`stellar-cli`]: https://github.com/stellar/stellar-cli
+
+---
+
 This docker image provides a simple way to run all the components of a Stellar network locally or in CI for development and testing.
 
 > [!IMPORTANT]  


### PR DESCRIPTION
### What

Add to the top of the quickstart readme an example of how to run the image using the stellar-cli.

### Why

For developers using the image outside CI, we should promote and encourage how to use the stellar-cli to manage development containers. Ideally devs don't need to know the ins and outs of running the image locally.