### PR TITLE
Use Go version to 1.23 when building horizon

### DIFF
--- a/Dockerfile.horizon
+++ b/Dockerfile.horizon
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG REF
 WORKDIR /go/src/github.com/stellar/go


### PR DESCRIPTION
We are now building horizon with Go version 1.23, see https://github.com/stellar/go/pull/5561