### PR TITLE
Add libudev-dev and libdbus-1-dev dependencies

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -8,7 +8,8 @@ apt-get install -y curl apt-transport-https \
                    postgresql-client postgresql postgresql-contrib \
                    sudo supervisor psmisc \
                    nginx rsync jq netcat \
-                   libunwind8 sqlite libc++abi1-12 libc++1-12
+                   libunwind8 sqlite libc++abi1-12 libc++1-12 \
+                   libudev-dev libdbus-1-dev
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Closes https://github.com/stellar/system-test/issues/116

Adding libudev-dev and libdbus-1-dev as dependencies - libudev-dev is needed for ledger support (upcoming), and libdbus-1-dev is needed for the crate we are using to support keychain signing.