### PR TITLE
Update stellar-cli command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Install the [`stellar-cli`] and start development containers running this image with:
 >
 > ```
-> stellar container start local
+> stellar container start
 > ```
 
 [`stellar-cli`]: https://github.com/stellar/stellar-cli


### PR DESCRIPTION
### What
Removes 'local' argument from container start command in README.

### Why
The argument is optional as of:
- https://github.com/stellar/stellar-cli/pull/1852