### PR TITLE
Update XDR dockerfile

### DIFF
--- a/Dockerfile.xdr
+++ b/Dockerfile.xdr
@@ -6,4 +6,5 @@ WORKDIR /wd
 RUN git clone ${REPO} /wd
 RUN git fetch origin ${REF}
 RUN git checkout ${REF}
+RUN rustup show active-toolchain || rustup toolchain install
 RUN cargo install stellar-xdr --features cli --path . --locked


### PR DESCRIPTION
After [new rustup change](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280) we need to manually install toolchains.
As the result, a lot of our build tooling started to fail (e.g. [systems test](https://github.com/stellar/system-test/pull/120))
This PR tries to fix that

Before:
```
> docker build . -f Dockerfile.xdr --build-arg REPO=https://github.com/stellar/rs-stellar-xdr --build-arg REF=c356a8cdcf59e91bd2224edda45eff337335ccfb
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  1.225MB
Step 1/8 : FROM rust:1.85.0 AS builder
1.85.0: Pulling from library/rust
Digest: sha256:e15c642b487dd013b2e425d001d32927391aca787ac582b98cca72234d466b60
Status: Downloaded newer image for rust:1.85.0
 ---> 0aac1c9ca934
Step 2/8 : ARG REPO
 ---> Using cache
 ---> a4576c65bbed
Step 3/8 : ARG REF
 ---> Using cache
 ---> 22f89ee7a75e
Step 4/8 : WORKDIR /wd
 ---> Using cache
 ---> 971a5d28faa8
Step 5/8 : RUN git clone ${REPO} /wd
 ---> Using cache
 ---> 29ab06ed1adf
Step 6/8 : RUN git fetch origin ${REF}
 ---> Using cache
 ---> dc6475b2ecb7
Step 7/8 : RUN git checkout ${REF}
 ---> Using cache
 ---> 0bdf8eb01270
Step 8/8 : RUN cargo install stellar-xdr --features cli --path . --locked
 ---> Running in 0e8154bb2ae2
error: toolchain 'stable-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install stable-x86_64-unknown-linux-gnu` to install it
The command '/bin/sh -c cargo install stellar-xdr --features cli --path . --locked' returned a non-zero code: 1
```

After:
```
 docker build . -f Dockerfile.xdr --build-arg REPO=https://github.com/stellar/rs-stellar-xdr --build-arg REF=c356a8cdcf59e91bd2224edda45eff337335ccfb
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  1.225MB
Step 1/9 : FROM rust AS builder
 ---> 0aac1c9ca934
Step 2/9 : ARG REPO
 ---> Using cache
 ---> a4576c65bbed
Step 3/9 : ARG REF
 ---> Using cache
 ---> 22f89ee7a75e
Step 4/9 : WORKDIR /wd
 ---> Using cache
 ---> 971a5d28faa8
Step 5/9 : RUN git clone ${REPO} /wd
 ---> Using cache
 ---> 29ab06ed1adf
Step 6/9 : RUN git fetch origin ${REF}
 ---> Using cache
 ---> dc6475b2ecb7
Step 7/9 : RUN git checkout ${REF}
 ---> Using cache
 ---> 0bdf8eb01270
Step 8/9 : RUN rustup show active-toolchain || rustup toolchain install
 ---> Running in 28962f7a1ddf
error: override toolchain 'stable-x86_64-unknown-linux-gnu' is not installed: the toolchain file at '/wd/rust-toolchain.toml' specifies an uninstalled toolchain
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'
info: latest update on 2025-02-20, rust version 1.85.0 (4d91de4e4 2025-02-17)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-src'
info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-src'
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
info: installing component 'rust-std'
info: installing component 'rustc'
info: installing component 'rustfmt'
info: the active toolchain `stable-x86_64-unknown-linux-gnu` has been installed
info: it's active because: overridden by '/wd/rust-toolchain.toml'
 ---> Removed intermediate container 28962f7a1ddf
 ---> 4f9f25198c07
Step 9/9 : RUN cargo install stellar-xdr --features cli --path . --locked
 ---> Running in 2c526305f5bb
```