### PR TITLE
Update Horizon version 22.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,27 +26,27 @@ build-latest:
 		PROTOCOL_VERSION_DEFAULT=22 \
 		XDR_REF=v22.0.0 \
 		CORE_REF=v22.2.0 \
-		HORIZON_REF=horizon-v22.0.2 \
+		HORIZON_REF=horizon-v22.0.3 \
 		STELLAR_RPC_REF=v22.1.2 \
-		FRIENDBOT_REF=horizon-v22.0.2
+		FRIENDBOT_REF=horizon-v22.0.3
 
 build-testing:
 	$(MAKE) build TAG=testing \
 	    PROTOCOL_VERSION_DEFAULT=22 \
 		XDR_REF=v22.0.0 \
 		CORE_REF=v22.2.0 \
-		HORIZON_REF=horizon-v22.0.2 \
+		HORIZON_REF=horizon-v22.0.3 \
 		STELLAR_RPC_REF=v22.1.2 \
-		FRIENDBOT_REF=horizon-v22.0.2
+		FRIENDBOT_REF=horizon-v22.0.3
 
 build-future:
 	$(MAKE) build TAG=future \
 		PROTOCOL_VERSION_DEFAULT=22 \
 		XDR_REF=v22.0.0 \
 		CORE_REF=v22.2.0 \
-		HORIZON_REF=horizon-v22.0.2 \
+		HORIZON_REF=horizon-v22.0.3 \
 		STELLAR_RPC_REF=v22.1.2 \
-		FRIENDBOT_REF=horizon-v22.0.2
+		FRIENDBOT_REF=horizon-v22.0.3
 
 build:
 	$(MAKE) -j 4 build-deps


### PR DESCRIPTION
Update Horizon to the latest version: [Horizon v22.0.3](https://github.com/stellar/go/releases/tag/horizon-v22.0.3).