### PR TITLE
Fix friendbot not starting with different network passphrases

### DIFF
--- a/common/friendbot/etc/friendbot.cfg
+++ b/common/friendbot/etc/friendbot.cfg
@@ -1,6 +1,6 @@
 port = 8002
-friendbot_secret = "SC5O7VZUXDJ6JBDSZ74DSERXL7W3Y5LTOAMRF7RQRL3TAGAPS7LUVG3L"
-network_passphrase = "Standalone Network ; February 2017"
+friendbot_secret = "__NETWORK_ROOT_SECRET_KEY__"
+network_passphrase = "__NETWORK__"
 horizon_url = "http://localhost:8001"
 starting_balance = "10000.00"
 num_minions = 10

--- a/start
+++ b/start
@@ -206,7 +206,9 @@ function process_args() {
     export HISTORY_ARCHIVE_URLS="https://history.stellar.org/prd/core-live/core_live_001"
     ;;
   local)
-    export NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    if [ -z "$NETWORK_PASSPHRASE" ]; then
+      export NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    fi
     # h1570ry - we'll start a webserver connected to history directory later on
     export HISTORY_ARCHIVE_URLS="http://localhost:1570"
     ENABLE_CORE=true

--- a/start
+++ b/start
@@ -94,6 +94,7 @@ function start() {
   validate_after_copy_defaults
   init_db
   init_stellar_core
+  init_friendbot
   init_horizon
   copy_pgpass
   init_stellar_rpc
@@ -439,6 +440,15 @@ function init_stellar_core() {
   fi
 
   touch .quickstart-initialized
+  popd
+}
+
+function init_friendbot() {
+  pushd $FBHOME
+
+  perl -pi -e "s/__NETWORK__/$NETWORK_PASSPHRASE/g" etc/friendbot.cfg
+  perl -pi -e "s/__NETWORK_ROOT_SECRET_KEY__/$NETWORK_ROOT_SECRET_KEY/g" etc/friendbot.cfg
+
   popd
 }
 


### PR DESCRIPTION
### What
  Update friendbot configuration file with placeholders that are replaced during initialization with the network's passphrase and root secret key.

  ### Why
  Friendbot has a fixed configuration in the image that only works with the network passphrase set to a specific phrase. However the image is designed to be used as a development / testing network with random passphrases, so that when deploying to a shared public URL the network has a unique network passphrase so that txs signed for it don't overlap with any other network.

Close #335 

Blocks:
- #299 
- https://github.com/stellar/stellar-docs/pull/1543