### PR TITLE
Allow setting custom network passphrase in local mode

### DIFF
--- a/start
+++ b/start
@@ -206,7 +206,9 @@ function process_args() {
     export HISTORY_ARCHIVE_URLS="https://history.stellar.org/prd/core-live/core_live_001"
     ;;
   local)
-    export NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    if [ -z "$NETWORK_PASSPHRASE" ]; then
+      export NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+    fi
     # h1570ry - we'll start a webserver connected to history directory later on
     export HISTORY_ARCHIVE_URLS="http://localhost:1570"
     ENABLE_CORE=true


### PR DESCRIPTION
### What
  Add ability to override the network passphrase in local mode.

  ### Why
  Allows developers using the image to run local mode with a different network passphrase. Helpful when running a shared test network and wanting to give it a meaningful and unique network name, or wanting to ensure that txs signed for a test network do not overlap with any other test networks.

The ability to get a unique network name is already supported by the ability to set a randomized network passphrase, but that can be inconvenient to use in some situations since every boot will result in a new passphrase.

Close #299

### Merging

Intended on merging to `main` after:
- #687 