### PR TITLE
Make lab smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,16 +34,9 @@ COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
 COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
 COPY --from=stellar-rpc /bin/stellar-rpc /usr/bin/stellar-rpc
-COPY --from=lab /lab /opt/stellar/lab
-COPY --from=lab /usr/local/bin/node \
-                /usr/local/bin/npm \
-                /usr/local/bin/corepack \
-                /usr/local/bin/npx \
-                /usr/local/bin/yarn \
-                /usr/local/bin/yarnpkg \
-                /usr/bin/
-COPY --from=lab /usr/local/include/node /usr/local/include/node
-COPY --from=lab /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=lab /lab/build/standalone /opt/stellar/lab
+COPY --from=lab /lab/build/static /opt/stellar/lab/public/_next/static
+COPY --from=lab /usr/local/bin/node /usr/bin/
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Dockerfile.lab
+++ b/Dockerfile.lab
@@ -15,4 +15,4 @@ ENV NEXT_BASE_PATH=/lab
 RUN yarn build
 
 EXPOSE 8100
-CMD ["npm", "start"]
+CMD ["node", "build/standalone/server.js"]

--- a/common/lab/bin/start
+++ b/common/lab/bin/start
@@ -8,4 +8,4 @@ export PORT=8100
 export NEXT_BASE_PATH=/lab
 export NEXT_PUBLIC_DEFAULT_NETWORK=custom
 export NEXT_PUBLIC_ENABLE_EXPLORER=true
-./node_modules/.bin/next start
+node server.js


### PR DESCRIPTION
### What

Reduce the lab files embedded into the image to only the files needed to run lab.

#### Before lab
Uncompressed: 0.70G
Compressed: 0.23G
https://hub.docker.com/layers/stellar/quickstart/v481-future/images/sha256-7480e1b3f568ee4848bb907854266de13e04e83a8610b6bdafa5ed5bf6495d33

#### After lab, Before this PR
Uncompressed: 2.33G
Compressed: 0.60G
https://hub.docker.com/layers/stellar/quickstart/v484-future/images/sha256-0528af8c7585d32533bc0ba2b33772f18c4809f27d0183e0cd40f48399e8897c

#### After this PR
Uncompressed: 0.91G
Compressed: 0.29G
https://hub.docker.com/layers/stellar/quickstart/pr706-v485-future/images/sha256-75cd5dc2f3a8c6e22765fdfdeb4f9ef4929ca90c7b9ad3eb1eed6c97550ec153

### Why

Quickstart got bigger when we added lab. We followed the instructions in the lab repo for how to use the production build, but it turns out lab actually builds a standalone version of Next.js that is smaller in size and can be used instead. 

Close #695

Related:
- https://github.com/stellar/laboratory/pull/1491