### PR TITLE
Configure ARM64 runner for ARM64 image tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,7 +416,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(inputs.test_matrix) }}
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-jammy-4-cores-arm64' || 'ubuntu-latest' }}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
### What
  Configure GitHub Actions to use an ARM64 runner when the image being tested is the ARM64 image.

  ### Why
  