### PR TITLE
Fix supervisorctl command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password
 RUN ["mkdir", "-p", "/opt/stellar"]
 RUN ["touch", "/opt/stellar/.docker-ephemeral"]
 
+RUN ["rm", "-fr", "/etc/supervisor"]
+RUN ["ln", "-sT", "/opt/stellar/supervisor/etc", "/etc/supervisor"]
+
 RUN ["ln", "-s", "/opt/stellar", "/stellar"]
 RUN ["ln", "-s", "/opt/stellar/core/etc/stellar-core.cfg", "/stellar-core.cfg"]
 RUN ["ln", "-s", "/opt/stellar/horizon/etc/horizon.env", "/horizon.env"]

--- a/start
+++ b/start
@@ -826,8 +826,4 @@ function horizon_status() {
   echo "horizon: ingestion caught up"
 }
 
-function supervisorctl() {
-  /usr/bin/supervisorctl -c $SUPHOME/etc/supervisord.conf "$@"
-}
-
 main $@


### PR DESCRIPTION
### What
  Create a symlink from the default supervisorctl config location to the Stellar supervisorctl config location.

  ### Why
  Allows supervisorctl to find the config automatically without requiring additional command options.

In #690 I changed the way that supervisorctl communicates with supervisord to use inet_http_server instead of unix_http_server. This had the side effect of needing to specify the config file location when running supervisorctl, because the default config stored at /etc/supervisor/supervisor.conf specifies supervisorctl should connect via unix_http_server. So after that change running supervisorctl will read the default config and try to connect to the unix socket rather than the inet.

All of this arises from the fact that the image has always had two supervisor.confs, the one in the default location that luckily pointed to the correct connection, and the one in the stellar directory which contained the actual config we wanted to use.

Fixing this by symlinking the actual config into the default location is a simple way to get the ctl and daemon to always pickup the correct config.

Close #719