### PR TITLE
Add protocol version option to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The action supports several configuration options. None are required and default
     image: "docker.io/stellar/quickstart" # Image name (default: "docker.io/stellar/quickstart")
     network: "local"                      # Network: local, testnet, futurenet (default: "local")
     enable: "core,horizon,rpc"            # Services to enable (default: "core,horizon,rpc")
+    protocol_version: ""                  # Protocol version to run for 'local' network only (leave blank for default for image)"
     enable_logs: "true"                   # Enable container logs (default: "true")
     health_interval: "10"                 # Time between health checks in seconds (default: "10")
     health_timeout: "5"                   # Maximum time for each health check in seconds (default: "5")

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   network:
     description: "Network to run"
     default: "local"
+  protocol_version:
+    description: "Protocol version to run for 'local' network only (leave blank for default for image)"
+    default: ""
   enable_logs:
     description: "Boolean flag enabling the logs"
     default: "true"
@@ -57,6 +60,7 @@ runs:
         -e ENABLE_LOGS="${{ inputs.enable_logs }}"
         -e ENABLE="${{ inputs.enable }}"
         -e NETWORK="${{ inputs.network }}" 
+        -e PROTOCOL_VERSION="${{ inputs.protocol_version }}" 
         --health-cmd "curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
         '{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"getHealth\"}' 'http://localhost:8000/rpc' 
         | grep 'healthy'

--- a/start
+++ b/start
@@ -93,6 +93,8 @@ function start() {
   echo "network id: $NETWORK_ID"
   echo "network root secret key: $NETWORK_ROOT_SECRET_KEY"
   echo "network root account id: $NETWORK_ROOT_ACCOUNT_ID"
+  echo "protocol version default: $PROTOCOL_VERSION_DEFAULT"
+  echo "protocol version set: $PROTOCOL_VERSION"
 
   copy_defaults
   validate_after_copy_defaults


### PR DESCRIPTION
### What
  Add protocol version input to GitHub Action for specifying the Stellar protocol version when running on the local network.

  ### Why
  Enables testing against specific protocol versions, helping developers verify compatibility with different Stellar Protocol releases. The image supports this parameter, it just isn't exposed in the GitHub Action.