### PR TITLE
Remove 'j' from build-testing.yml

### DIFF
--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -41,7 +41,7 @@ jobs:
       friendbot_ref: horizon-v23.0.0
       lab_ref: main
       test_matrix: |
-        {j
+        {
           "network": ["testnet", "pubnet", "local"],
           "core": ["core", null],
           "horizon": ["horizon", null],


### PR DESCRIPTION
### What

Remove a stray `j` character in the test macris of the testing build workflow.

### Why

It isn't supposed to be there. The test matrix should be valid json.