### PR TITLE
Fix issue in running build/test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,6 +339,7 @@ jobs:
 
   build:
     needs: [build-stellar-core, build-stellar-horizon, build-rs-stellar-xdr, build-stellar-friendbot, build-stellar-rpc, build-stellar-lab]
+    if: always()
     outputs:
       image: ${{ steps.image.outputs.name }}
     runs-on: ubuntu-latest
@@ -436,6 +437,7 @@ jobs:
 
   test:
     needs: build
+    if: always()
     strategy:
       matrix: ${{ fromJSON(inputs.test_matrix) }}
       fail-fast: false


### PR DESCRIPTION
### What
  Add 'if: always()' condition to build and test jobs to run regardless of prior job failures and skips.

  ### Why
  Earlier jobs in the flow can be skipped because of cache usage, and GH workflows will not run the build job if an earlier job skipped. We could have made those earlier jobs still run and skipped steps instead, but because those earlier runs use high cost runners, it is more cost effective and in many cases time effective to skip the entire job.

I had removed the always in https://github.com/stellar/quickstart/pull/737.