### PR TITLE
Move action test workflow into build

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,44 +1,40 @@
-name: Action test
+name: Action Test
 
 on:
   workflow_call:
     inputs:
-      test_tags:
-        description: 'Test tags to use'
+      tag:
+        description: 'Tag to use'
         type: 'string'
         default: ''
 
 jobs:
-  basic-test:
-    name: Basic tests
+  test:
     strategy:
       fail-fast: false
       matrix:
         sys:
-          # x64
-          - os: ubuntu-latest-16-cores
-            # ARM
-          - os: ubuntu-jammy-16-cores-arm64
-            # Intel
-          - os: macos-13
-        tag: ${{ fromJSON(inputs.test_tags) }}
+        - os: ubuntu-latest-16-cores # x86
+        - os: ubuntu-jammy-16-cores-arm64 # ARM64
+        - os: macos-13 # macOS Intel
+        - os: macos-latest # macOS ARM64
     runs-on: ${{ matrix.sys.os }}
     steps:
-      - uses: stellar/quickstart@main
-        with:
-          tag: ${{ matrix.tag }}
-      - name: "Run basic test making sure RPC and Horizon are available"
-        run: >
-          RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
-          '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
-          
-          echo "RPC getLatestLedger response: $RESP"
+    - uses: stellar/quickstart@main
+      with:
+        tag: ${{ inputs.tag }}
+    - name: "Run basic test making sure RPC and Horizon are available"
+      run: >
+        RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
+        '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
+        
+        echo "RPC getLatestLedger response: $RESP"
 
-          echo "$RESP" | grep sequence
-          
-          RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
-          -H 'Accept: application/json'`
-          
-          echo "Horizon ledgers response: $RESP"
-          
-          echo "$RESP" | grep "200 OK"
+        echo "$RESP" | grep sequence
+        
+        RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
+        -H 'Accept: application/json'`
+        
+        echo "Horizon ledgers response: $RESP"
+        
+        echo "$RESP" | grep "200 OK"

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -70,17 +70,3 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
-
-  action-test-merge:
-    needs: [latest, testing]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["latest", "testing"]'
-
-  action-test-pr:
-    needs: [latest, testing]
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["${{ needs.setup.outputs.tag-prefix }}latest", "${{ needs.setup.outputs.tag-prefix }}testing"]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -583,3 +583,10 @@ jobs:
         registry: ${{ secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io' }}
         username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
         password: ${{ secrets.DOCKERHUB_TOKEN || github.token }}
+
+  action-test:
+    needs: [push-pr, push-release]
+    if: ${{ always() }}
+    uses: ./.github/workflows/action-test.yml
+    with:
+      tag: ${{ inputs.tag }}


### PR DESCRIPTION
### What
  Consolidate action test workflow by moving it from build-start to build workflow. Run the test on a single tag per build instead of across multiple after all complete.

  ### Why
  The action test doesn't need different test runs for the main branch and pr branches. It can be run test run. Also, it doesn't need to wait for all builds to finish before kicking off each, we can kick off each within.