### PR TITLE
Improvements to the GitHub Action tests

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,44 +1,39 @@
-name: Action test
+name: Action Test
 
 on:
   workflow_call:
     inputs:
-      test_tags:
-        description: 'Test tags to use'
+      tag:
+        description: 'Tag to use'
         type: 'string'
         default: ''
 
 jobs:
-  basic-test:
-    name: Basic tests
+  action-test:
     strategy:
       fail-fast: false
       matrix:
         sys:
-          # x64
-          - os: ubuntu-latest-16-cores
-            # ARM
-          - os: ubuntu-jammy-16-cores-arm64
-            # Intel
-          - os: macos-13
-        tag: ${{ fromJSON(inputs.test_tags) }}
+        - os: ubuntu-latest-16-cores # x64
+        - os: ubuntu-jammy-16-cores-arm64 # ARM
+        - os: macos-13 # Intel
     runs-on: ${{ matrix.sys.os }}
     steps:
-      - uses: stellar/quickstart@main
-        with:
-          tag: ${{ matrix.tag }}
-      - name: "Run basic test making sure RPC and Horizon are available"
-        run: >
-          RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
-          '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
-          
-          echo "RPC getLatestLedger response: $RESP"
+    - uses: stellar/quickstart@main
+      with:
+        tag: ${{ inputs.tag }}
+    - name: "Run basic test making sure RPC and Horizon are available"
+      run: >
+        RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
+        '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
+        
+        echo "RPC getLatestLedger response: $RESP"
 
-          echo "$RESP" | grep sequence
-          
-          RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
-          -H 'Accept: application/json'`
-          
-          echo "Horizon ledgers response: $RESP"
-          
-          echo "$RESP" | grep "200 OK"
+        echo "$RESP" | grep sequence
+        
+        RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
+        -H 'Accept: application/json'`
+        
+        echo "Horizon ledgers response: $RESP"
+        
+        echo "$RESP" | grep "200 OK"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -18,7 +18,7 @@ jobs:
         - os: ubuntu-jammy-16-cores-arm64 # ARM
         - os: macos-13 # Intel
     runs-on: ${{ matrix.sys.os }}
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
     - uses: ./

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -18,6 +18,7 @@ jobs:
         - os: ubuntu-jammy-16-cores-arm64 # ARM
         - os: macos-13 # Intel
     runs-on: ${{ matrix.sys.os }}
+    timeout-minutes: 20
     steps:
     - uses: stellar/quickstart@main
       with:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -9,7 +9,7 @@ on:
         default: ''
 
 jobs:
-  test:
+  action-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,39 +1,44 @@
-name: Action Test
+name: Action test
 
 on:
   workflow_call:
     inputs:
-      tag:
-        description: 'Tag to use'
+      test_tags:
+        description: 'Test tags to use'
         type: 'string'
         default: ''
 
 jobs:
-  action-test:
+  basic-test:
+    name: Basic tests
     strategy:
       fail-fast: false
       matrix:
         sys:
-        - os: ubuntu-latest-16-cores # x86
-        - os: ubuntu-jammy-16-cores-arm64 # ARM64
-        - os: macos-13 # macOS Intel
+          # x64
+          - os: ubuntu-latest-16-cores
+            # ARM
+          - os: ubuntu-jammy-16-cores-arm64
+            # Intel
+          - os: macos-13
+        tag: ${{ fromJSON(inputs.test_tags) }}
     runs-on: ${{ matrix.sys.os }}
     steps:
-    - uses: stellar/quickstart@main
-      with:
-        tag: ${{ inputs.tag }}
-    - name: "Run basic test making sure RPC and Horizon are available"
-      run: >
-        RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
-        '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
-        
-        echo "RPC getLatestLedger response: $RESP"
+      - uses: stellar/quickstart@main
+        with:
+          tag: ${{ matrix.tag }}
+      - name: "Run basic test making sure RPC and Horizon are available"
+        run: >
+          RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
+          '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
+          
+          echo "RPC getLatestLedger response: $RESP"
 
-        echo "$RESP" | grep sequence
-        
-        RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
-        -H 'Accept: application/json'`
-        
-        echo "Horizon ledgers response: $RESP"
-        
-        echo "$RESP" | grep "200 OK"
+          echo "$RESP" | grep sequence
+          
+          RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
+          -H 'Accept: application/json'`
+          
+          echo "Horizon ledgers response: $RESP"
+          
+          echo "$RESP" | grep "200 OK"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 20
     steps:
-    - uses: stellar/quickstart@main
+    - uses: stellar/quickstart@${{ github.sha }}
       with:
         tag: ${{ inputs.tag }}
     - name: "Run basic test making sure RPC and Horizon are available"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
-    - uses: ./action.yml
+    - uses: ./
       with:
         tag: ${{ inputs.tag }}
     - name: "Run basic test making sure RPC and Horizon are available"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,44 +1,40 @@
-name: Action test
+name: Action Test
 
 on:
   workflow_call:
     inputs:
-      test_tags:
-        description: 'Test tags to use'
+      tag:
+        description: 'Tag to use'
         type: 'string'
         default: ''
 
 jobs:
-  basic-test:
-    name: Basic tests
+  test:
     strategy:
       fail-fast: false
       matrix:
         sys:
-          # x64
-          - os: ubuntu-latest-16-cores
-            # ARM
-          - os: ubuntu-jammy-16-cores-arm64
-            # Intel
-          - os: macos-13
-        tag: ${{ fromJSON(inputs.test_tags) }}
+        - os: ubuntu-latest-16-cores # x86
+        - os: ubuntu-jammy-16-cores-arm64 # ARM64
+        - os: macos-13 # macOS Intel
+        - os: macos-latest # macOS ARM64
     runs-on: ${{ matrix.sys.os }}
     steps:
-      - uses: stellar/quickstart@main
-        with:
-          tag: ${{ matrix.tag }}
-      - name: "Run basic test making sure RPC and Horizon are available"
-        run: >
-          RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
-          '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
-          
-          echo "RPC getLatestLedger response: $RESP"
+    - uses: stellar/quickstart@main
+      with:
+        tag: ${{ inputs.tag }}
+    - name: "Run basic test making sure RPC and Horizon are available"
+      run: >
+        RESP=`curl --no-progress-meter -X POST -H 'Content-Type: application/json' -d 
+        '{"jsonrpc": "2.0", "id": 8675309, "method": "getLatestLedger"}' http://localhost:8000/rpc`
+        
+        echo "RPC getLatestLedger response: $RESP"
 
-          echo "$RESP" | grep sequence
-          
-          RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
-          -H 'Accept: application/json'`
-          
-          echo "Horizon ledgers response: $RESP"
-          
-          echo "$RESP" | grep "200 OK"
+        echo "$RESP" | grep sequence
+        
+        RESP=`curl -i -o - --silent 'http://localhost:8000/ledgers?limit=1'
+        -H 'Accept: application/json'`
+        
+        echo "Horizon ledgers response: $RESP"
+        
+        echo "$RESP" | grep "200 OK"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ./action.yml
       with:
         tag: ${{ inputs.tag }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 20
     steps:
-    - uses: stellar/quickstart@${{ github.sha }}
+    - uses: actions/checkout@v2
+    - uses: ./action.yml
       with:
         tag: ${{ inputs.tag }}
     - name: "Run basic test making sure RPC and Horizon are available"

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -17,7 +17,6 @@ jobs:
         - os: ubuntu-latest-16-cores # x86
         - os: ubuntu-jammy-16-cores-arm64 # ARM64
         - os: macos-13 # macOS Intel
-        - os: macos-latest # macOS ARM64
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: stellar/quickstart@main

--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -19,6 +19,10 @@ on:
         description: "Prefix for the tag name"
         type: "string"
         default: ""
+      tag-alias-prefix:
+        description: 'Prefix for the alias tag name'
+        type: 'string'
+        default: ''
 
 jobs:
   amd64:
@@ -79,5 +83,5 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       tag: ${{ inputs.tag-prefix }}future
-      tag-alias: future
+      tag-alias: ${{ inputs.tag-alias-prefix }}future
       images: ${{ needs.amd64.outputs.image }} ${{ needs.arm64.outputs.image }}

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -20,6 +20,10 @@ on:
         description: 'Prefix for the tag name'
         type: 'string'
         default: ''
+      tag-alias-prefix:
+        description: 'Prefix for the alias tag name'
+        type: 'string'
+        default: ''
 
 jobs:
 
@@ -81,5 +85,5 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       tag: ${{ inputs.tag-prefix }}latest
-      tag-alias: latest
+      tag-alias: ${{ inputs.tag-alias-prefix }}latest
       images: ${{ needs.amd64.outputs.image }} ${{ needs.arm64.outputs.image }}

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -38,6 +38,7 @@ jobs:
         pr_prefix="${{ github.event_name == 'pull_request' && format('pr{0}-', github.event.pull_request.number) }}"
         count="$(git rev-list HEAD --count --first-parent)"
         echo "tag-prefix=${pr_prefix}v${count}-" >> $GITHUB_OUTPUT
+        echo "tag-alias-prefix=${pr_prefix}" >> $GITHUB_OUTPUT
 
   latest:
     needs: [setup]
@@ -48,6 +49,7 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
+      tag-alias-prefix: ${{ needs.setup.outputs.tag-alias-prefix }}
 
   latest-action-test:
     needs: [setup, latest]
@@ -65,6 +67,7 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
+      tag-alias-prefix: ${{ needs.setup.outputs.tag-alias-prefix }}
 
   testing-action-test:
     needs: [setup, testing]
@@ -82,3 +85,4 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
+      tag-alias-prefix: ${{ needs.setup.outputs.tag-alias-prefix }}

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -71,7 +71,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/action-test.yml
     with:
-      test_tags: ${{ needs.setup.outputs.tag-prefix }}testing"]'
+      tag: ${{ needs.setup.outputs.tag-prefix }}testing
 
   future:
     needs: [setup]

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -35,8 +35,9 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - id: tag-prefix
       run: |
+        pr_prefix="${{ github.event_name == 'pull_request' && format('pr{0}-', github.event.pull_request.number) }}"
         count="$(git rev-list HEAD --count --first-parent)"
-        echo "tag-prefix=v${count}-" >> $GITHUB_OUTPUT
+        echo "tag-prefix=${pr_prefix}v${count}-" >> $GITHUB_OUTPUT
 
   latest:
     needs: [setup]

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -18,7 +18,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [latest, testing, future]
+    needs: [latest, testing, future, action-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
@@ -49,6 +49,13 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
 
+  latest-action-test:
+    needs: [latest]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/action-test.yml
+    with:
+      tag: ${{ needs.setup.outputs.tag-prefix }}latest
+
   testing:
     needs: [setup]
     uses: ./.github/workflows/build-testing.yml
@@ -59,6 +66,13 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
 
+  testing-action-test:
+    needs: [testing]
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/action-test.yml
+    with:
+      test_tags: ${{ needs.setup.outputs.tag-prefix }}testing"]'
+
   future:
     needs: [setup]
     uses: ./.github/workflows/build-future.yml
@@ -68,17 +82,3 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
-
-  action-test-merge:
-    needs: [latest, testing]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["latest", "testing"]'
-
-  action-test-pr:
-    needs: [latest, testing]
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["${{ needs.setup.outputs.tag-prefix }}latest", "${{ needs.setup.outputs.tag-prefix }}testing"]'

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -68,3 +68,17 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
+
+  action-test-merge:
+    needs: [latest, testing]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/action-test.yml
+    with:
+      test_tags: '["latest", "testing"]'
+
+  action-test-pr:
+    needs: [latest, testing]
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/action-test.yml
+    with:
+      test_tags: '["${{ needs.setup.outputs.tag-prefix }}latest", "${{ needs.setup.outputs.tag-prefix }}testing"]'

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -18,7 +18,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [latest, testing, future, action-test]
+    needs: [latest, testing, future, latest-action-test, testing-action-test]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -18,10 +18,7 @@ jobs:
 
   complete:
     if: always()
-    needs:
-    - action-test-merge
-    - action-test-pr
-    # - future
+    needs: [latest, testing, future]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -50,7 +50,7 @@ jobs:
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
 
   latest-action-test:
-    needs: [latest]
+    needs: [setup, latest]
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/action-test.yml
     with:
@@ -67,7 +67,7 @@ jobs:
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
 
   testing-action-test:
-    needs: [testing]
+    needs: [setup, testing]
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/action-test.yml
     with:

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -70,17 +70,3 @@ jobs:
     with:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       tag-prefix: ${{ needs.setup.outputs.tag-prefix }}
-
-  action-test-merge:
-    needs: [latest, testing]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["latest", "testing"]'
-
-  action-test-pr:
-    needs: [latest, testing]
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/action-test.yml
-    with:
-      test_tags: '["${{ needs.setup.outputs.tag-prefix }}latest", "${{ needs.setup.outputs.tag-prefix }}testing"]'

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -21,6 +21,10 @@ on:
         description: 'Prefix for the tag name'
         type: 'string'
         default: ''
+      tag-alias-prefix:
+        description: 'Prefix for the alias tag name'
+        type: 'string'
+        default: ''
 
 jobs:
 
@@ -82,5 +86,5 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       tag: ${{ inputs.tag-prefix }}testing
-      tag-alias: testing
+      tag-alias: ${{ inputs.tag-alias-prefix }}testing
       images: ${{ needs.amd64.outputs.image }} ${{ needs.arm64.outputs.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -583,3 +583,10 @@ jobs:
         registry: ${{ secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io' }}
         username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
         password: ${{ secrets.DOCKERHUB_TOKEN || github.token }}
+
+  action-test:
+    needs: [push-pr, push-release]
+    if: ${{ always() }}
+    uses: ./.github/workflows/action-test.yml
+    with:
+      tag: ${{ inputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ on:
         value: ${{ jobs.build.outputs.image }}
 
 env:
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, inputs.tag) }}
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -583,10 +583,3 @@ jobs:
         registry: ${{ secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io' }}
         username: ${{ secrets.DOCKERHUB_USERNAME || github.actor }}
         password: ${{ secrets.DOCKERHUB_TOKEN || github.token }}
-
-  action-test:
-    needs: [push-pr, push-release]
-    if: ${{ always() }}
-    uses: ./.github/workflows/action-test.yml
-    with:
-      tag: ${{ inputs.tag }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -25,8 +25,8 @@ on:
 
 env:
   HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
-  IMAGE_ALIAS: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, inputs.tag-alias) || inputs.tag-alias) }}
+  IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, inputs.tag) }}
+  IMAGE_ALIAS: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, inputs.tag-alias) }}
   REGISTRY: ${{ secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io' }}
 
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -33,24 +33,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Check if Windows (unsupported)"
-      if: runner.os == 'Windows'
-      shell: powershell
-      run: |
-        echo "Windows runners are not supported"
-        exit 1
-    - name: "Check if macOS Apple Silicon (unsupported)"
-      if: runner.os == 'macOS' && (runner.arch == 'ARM' || runner.arch == 'ARM64')
-      shell: bash
-      run: |
-        echo "ARM MacOS runner is not yet supported, see https://github.com/douglascamata/setup-docker-macos-action"
-        exit 1
-    - name: Setup Colima and Docker (macOS only)
-      shell: bash
-      if: runner.os == 'macos'
-      run: |
-        brew install --formula docker colima
-        colima start
+    - name: Set up Docker
+      uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4
     - run: >
         docker run -d --name stellar 
         -p 8000:8000 


### PR DESCRIPTION
### What
Fix which image the action test pr build runs on.

Move the action-test workflow to run after each individual image build.

  Replace manual Docker setup using Homebrew with official Docker GitHub Action.

  ### Why

The action-test workflow was waiting for all image builds to finish, but it can start running on each image separately. Also the tag prefix that was being used by the action build didn't include the tag pr prefix because the tag pr prefix was being set lower down and the tag prefix known higher up didn't contain it.

  The homebrew install and setup of lima is really slow, leading to the action taking 12-12 minutes on a macos-13 instance. That's too long for realistic usage inside CI. Docker have an action that does a setup of lima and docker, and maybe it is faster. Giving it a go in this change.