### PR TITLE
Reduce build time by reducing the size of intermediary build stages to necessary files only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Build Stellar-Horizon Image
       run: >
         docker buildx build --platform linux/${{ inputs.arch }}
-        -f Dockerfile.horizon --target builder
+        -f Dockerfile.horizon
         -t stellar-horizon:${{ inputs.arch }} -o type=docker,dest=/tmp/image
         --build-arg REF="${{ needs.shas.outputs.horizon }}" .
     - name: Upload Stellar-Horizon Image
@@ -277,7 +277,7 @@ jobs:
     - name: Build Stellar-lab Image
       run: >
         docker buildx build --platform linux/${{ inputs.arch }}
-        -f Dockerfile.lab --target builder
+        -f Dockerfile.lab
         -t stellar-lab:${{ inputs.arch }} -o type=docker,dest=/tmp/image
         --build-arg NEXT_PUBLIC_COMMIT_HASH=${{ needs.shas.outputs.lab }} .
     - name: Upload Stellar-lab Image
@@ -326,7 +326,7 @@ jobs:
     - name: Build Stellar-Rs-Xdr Image
       run: >
         docker buildx build --platform linux/${{ inputs.arch }}
-        -f Dockerfile.xdr --target builder
+        -f Dockerfile.xdr
         -t stellar-rs-xdr:${{ inputs.arch }}
         -o type=docker,dest=/tmp/image
         --build-arg REPO=https://github.com/stellar/rs-stellar-xdr.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,10 @@ on:
 
 env:
   IMAGE: ${{ format('{0}/{1}:{2}', secrets.DOCKERHUB_TOKEN && 'docker.io' || 'ghcr.io', github.repository, github.event_name == 'pull_request' && format('pr{0}-{1}', github.event.pull_request.number, inputs.tag) || inputs.tag) }}
+  # Cache ID is a value inserted into cache keys. Whenever changing the build
+  # in a way that needs to use entirely new fresh builds, increment the number
+  # by one so that all the keys become new.
+  CACHE_ID: 1
 
 jobs:
 
@@ -103,7 +107,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-core-${{ inputs.arch }}-${{ needs.shas.outputs.core }}-${{ inputs.core_configure_flags }}
+        key: image-${{ env.CACHE_ID }}-stellar-core-${{ inputs.arch }}-${{ needs.shas.outputs.core }}-${{ inputs.core_configure_flags }}
     - name: Upload Stellar-Core Image
       if: steps.cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
@@ -120,7 +124,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-core-${{ inputs.arch }}-${{ needs.shas.outputs.core }}-${{ inputs.core_configure_flags }}
+        key: image-${{ env.CACHE_ID }}-stellar-core-${{ inputs.arch }}-${{ needs.shas.outputs.core }}-${{ inputs.core_configure_flags }}
     - if: inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       with:
@@ -199,7 +203,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-rpc-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
+        key: image-${{ env.CACHE_ID }}-stellar-rpc-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
     - name: Upload Stellar-Core Image
       if: steps.cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
@@ -216,7 +220,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-rpc-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
+        key: image-${{ env.CACHE_ID }}-stellar-rpc-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
     - if: inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       with:
@@ -246,7 +250,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-lab-${{ inputs.arch }}-${{ needs.shas.outputs.lab }}
+        key: image-${{ env.CACHE_ID }}-stellar-lab-${{ inputs.arch }}-${{ needs.shas.outputs.lab }}
     - name: Upload Stellar-Lab Image
       if: steps.cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
@@ -263,7 +267,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-lab-${{ inputs.arch }}-${{ needs.shas.outputs.lab }}
+        key: image-${{ env.CACHE_ID }}-stellar-lab-${{ inputs.arch }}-${{ needs.shas.outputs.lab }}
     - name: Checkout Quickstart for Horizon docker file
       uses: actions/checkout@v3
       with:
@@ -296,7 +300,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-rs-stellar-xdr-${{ inputs.arch }}-${{ needs.shas.outputs.xdr }}
+        key: image-${{ env.CACHE_ID }}-rs-stellar-xdr-${{ inputs.arch }}-${{ needs.shas.outputs.xdr }}
     - name: Upload Stellar-Core Image
       if: steps.cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
@@ -317,7 +321,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-rs-stellar-xdr-${{ inputs.arch }}-${{ needs.shas.outputs.xdr }}
+        key: image-${{ env.CACHE_ID }}-rs-stellar-xdr-${{ inputs.arch }}-${{ needs.shas.outputs.xdr }}
     - if: inputs.arch == 'arm64'
       uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,13 @@ EXPOSE 11626
 ADD dependencies /
 RUN /dependencies
 
-COPY --from=stellar-xdr /usr/local/cargo/bin/stellar-xdr /usr/local/bin/stellar-xdr
+COPY --from=stellar-xdr /stellar-xdr /usr/local/bin/stellar-xdr
 COPY --from=stellar-core /usr/local/bin/stellar-core /usr/bin/stellar-core
-COPY --from=horizon /go/bin/horizon /usr/bin/stellar-horizon
+COPY --from=horizon /horizon /usr/bin/stellar-horizon
 COPY --from=friendbot /app/friendbot /usr/local/bin/friendbot
 COPY --from=stellar-rpc /bin/stellar-rpc /usr/bin/stellar-rpc
-COPY --from=lab /lab/build/standalone /opt/stellar/lab
-COPY --from=lab /lab/build/static /opt/stellar/lab/public/_next/static
-COPY --from=lab /usr/local/bin/node /usr/bin/
+COPY --from=lab /lab /opt/stellar/lab
+COPY --from=lab /node /usr/bin/
 
 RUN adduser --system --group --quiet --home /var/lib/stellar --disabled-password --shell /bin/bash stellar;
 

--- a/Dockerfile.horizon
+++ b/Dockerfile.horizon
@@ -8,3 +8,7 @@ RUN git checkout ${REF}
 ENV CGO_ENABLED=0
 ENV GOFLAGS="-ldflags=-X=github.com/stellar/go/support/app.version=${REF}-(built-from-source)"
 RUN go install github.com/stellar/go/services/horizon
+
+FROM scratch AS artifacts
+
+COPY --from=builder /go/bin/horizon /horizon

--- a/Dockerfile.lab
+++ b/Dockerfile.lab
@@ -15,5 +15,8 @@ ENV NEXT_PUBLIC_DEFAULT_NETWORK=custom
 ENV NEXT_BASE_PATH=/lab
 RUN yarn build
 
-EXPOSE 8100
-CMD ["node", "build/standalone/server.js"]
+FROM scratch AS artifacts
+
+COPY --from=builder /lab/build/standalone /lab
+COPY --from=builder /lab/build/static /lab/public/_next/static
+COPY --from=builder /usr/local/bin/node /node

--- a/Dockerfile.xdr
+++ b/Dockerfile.xdr
@@ -8,3 +8,7 @@ RUN git fetch origin ${REF}
 RUN git checkout ${REF}
 RUN rustup show active-toolchain || rustup toolchain install
 RUN cargo install stellar-xdr --features cli --path . --locked
+
+FROM scratch AS artifacts
+
+COPY --from=builder /usr/local/cargo/bin/stellar-xdr /stellar-xdr

--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,13 @@ build:
 build-deps: build-deps-xdr build-deps-core build-deps-horizon build-deps-friendbot build-deps-stellar-rpc build-deps-lab
 
 build-deps-xdr:
-	docker build -t stellar-xdr:$(XDR_REF) -f Dockerfile.xdr --target builder . --build-arg REPO="$(XDR_REPO)" --build-arg REF="$(XDR_REF)"
+	docker build -t stellar-xdr:$(XDR_REF) -f Dockerfile.xdr . --build-arg REPO="$(XDR_REPO)" --build-arg REF="$(XDR_REF)"
 
 build-deps-core:
 	docker build -t stellar-core:$(CORE_REF) -f docker/Dockerfile.testing $(CORE_REPO)#$(CORE_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true --build-arg CONFIGURE_FLAGS="$(CORE_CONFIGURE_FLAGS)"
 
 build-deps-horizon:
-	docker build -t stellar-horizon:$(HORIZON_REF) -f Dockerfile.horizon --target builder . --build-arg REF="$(HORIZON_REF)"
+	docker build -t stellar-horizon:$(HORIZON_REF) -f Dockerfile.horizon . --build-arg REF="$(HORIZON_REF)"
 
 build-deps-friendbot:
 	docker build -t stellar-friendbot:$(FRIENDBOT_REF) -f services/friendbot/docker/Dockerfile https://github.com/stellar/go.git#$(FRIENDBOT_REF)
@@ -79,4 +79,4 @@ build-deps-stellar-rpc:
 	docker build -t stellar-rpc:$(STELLAR_RPC_REF) -f cmd/stellar-rpc/docker/Dockerfile --target build https://github.com/stellar/stellar-rpc.git#$(STELLAR_RPC_REF) --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
 
 build-deps-lab:
-	docker build -t stellar-lab:$(LAB_REF) -f Dockerfile.lab --target builder . --build-arg NEXT_PUBLIC_COMMIT_HASH=$(LAB_REF)
+	docker build -t stellar-lab:$(LAB_REF) -f Dockerfile.lab . --build-arg NEXT_PUBLIC_COMMIT_HASH=$(LAB_REF)


### PR DESCRIPTION
### What
  Restructure Docker build process leveraging multi-stage builds so that intermediary images contain only the files needed in subsequent stages.

  ### Why
  Reduce size of the intermediary images that are saved and loaded across build steps and are cached and loading in subsequent builds as well. Some of the newer images we added, like the lab, are large enough that the file loading takes more than 1 min in each job that needs to load the image file. The images contain all the files from the build, but we only need them to contain the final artifacts.

As a comparison of impact:
- The lab intermediary image was 2.2GB, but is now 0.08GB.
- It used to take ~3 minutes to move the image from cache to artifacts and load it into the docker runtime.
- It now takes ~7 seconds.

Saving a few minutes doesn't sound like much, but that's just for one image in one build. Each commit builds 6 different images, across 6 different configurations, some of which are on paid runners that have limited capacity. It multiplies.

### Follow-up

- [ ] Bring the RPC and Core dockerfiles into this repo so that we have more control over their build steps and the intermediary image. Why: RPC's image is still 1.3GB unnecessarily.