### PR TITLE
Fail faster on job failure or build cancellation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
 
   build:
     needs: [build-stellar-core, build-stellar-horizon, build-rs-stellar-xdr, build-stellar-friendbot, build-stellar-rpc, build-stellar-lab]
-    if: always()
+    if: always() && !failed() && !cancelled()
     outputs:
       image: ${{ steps.image.outputs.name }}
     runs-on: ubuntu-latest
@@ -437,7 +437,7 @@ jobs:
 
   test:
     needs: build
-    if: always()
+    if: always() && !failed() && !cancelled()
     strategy:
       matrix: ${{ fromJSON(inputs.test_matrix) }}
       fail-fast: false
@@ -538,7 +538,7 @@ jobs:
 
   push-pr:
     # Push image to registry after build for pull requests from a local branch.
-    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: always() && !failed() && !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: build
     permissions:
       packages: write
@@ -562,7 +562,7 @@ jobs:
 
   push-release:
     # Push image to registry after test for main.
-    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: always() && !failed() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build, test]
     permissions:
       packages: write


### PR DESCRIPTION
### What
  Add conditional checks to prevent workflow continuation if earlier jobs failed or the build was cancelled.

  ### Why
  The build workflow uses `always()` on some jobs so that they run, even if dependent jobs are skipped. By default if a dependent job is skipped, any job dependent on it also becomes skipped. But the workflow uses skipped jobs as a way to avoid consuming expensive runners. It uses cheap runners to check whether images are in the cache, and if they are the expensive build job is skipped. The final build job that builds the full image still needs to run even if the intermediary build jobs are skipped, so it uses `always()`. This has the unfortunate side-effect that if the build is cancelled, most of the subsequent jobs still need to run because they're marked as `always()`.

Adding in the additional conditionals on only continuing if not cancelled or failed will make the workflow only continue if the prior jobs are successful or skipped.

This should speed up PR iterations, because only a single commit is allowed to build at the one time in this repo to preserve costs, and when new commits are pushed the previous commits builds will fail and cancel out faster.