### PR TITLE
Run Action Tests only in PRs if action.yml changes

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -9,7 +9,7 @@ on:
         default: ''
 
 jobs:
-  action-setup-matrix:
+  action-setup:
     runs-on: ubuntu-latest
     outputs:
       os: ${{ steps.os.outputs.os }}
@@ -37,11 +37,11 @@ jobs:
         
 
   action-test:
-    needs: setup
+    needs: action-setup
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.setup.outputs.os) }}
+        os: ${{ fromJson(needs.action-setup.outputs.os) }}
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -29,8 +29,8 @@ jobs:
         echo '[' >> $GITHUB_OUTPUT
         echo '"ubuntu-latest-16-cores",' >> $GITHUB_OUTPUT
         ${{ steps.changes.outputs.action-changed == 'true' &&
-        echo '"ubuntu-jammy-16-cores-arm64",' >> $GITHUB_OUTPUT
-        echo '"macos-13",' >> $GITHUB_OUTPUT
+        'echo "ubuntu-jammy-16-cores-arm64", >> $GITHUB_OUTPUT
+        echo '"macos-13",' >> $GITHUB_OUTPUT'
         }}
         echo ']' >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         script: |
           const os = ['ubuntu-latest-16-cores'];
-          if ('${{ steps.changes.outputs.action-changed }}' === 'true') {
+          if (steps.changes.outputs['action-changed'] === 'true') {
             os.push('ubuntu-jammy-16-cores-arm64');
             os.push('macos-13');
           }

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -9,14 +9,32 @@ on:
         default: ''
 
 jobs:
+  action-setup:
+    runs-on: ubuntu-latest
+    outputs:
+      action-changed: ${{ steps.changes.outputs.action }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      id: changes
+      with:
+        filters: |
+          action:
+          - 'action.yml'
+
   action-test:
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         sys:
         - os: ubuntu-latest-16-cores # x64
+        ${{ fromJSON(needs.action-setup.outputs.action-changed == 'true' && '
         - os: ubuntu-jammy-16-cores-arm64 # ARM
         - os: macos-13 # Intel
+        ' || '') }}
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -25,10 +25,12 @@ jobs:
           - 'action.yml'
     - uses: actions/github-script@v8
       id: os
+      env:
+        ACTION_CHANGED: ${{ steps.changes.outputs.action-changed }}
       with:
         script: |
           const os = ['ubuntu-latest-16-cores'];
-          if (steps.changes.outputs['action-changed'] === 'true') {
+          if (process.env.ACTION_CHANGED === 'true') {
             os.push('ubuntu-jammy-16-cores-arm64');
             os.push('macos-13');
           }

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -30,7 +30,7 @@ jobs:
         echo '"ubuntu-latest-16-cores",' >> $GITHUB_OUTPUT
         ${{ steps.changes.outputs.action-changed == 'true' &&
         'echo "ubuntu-jammy-16-cores-arm64", >> $GITHUB_OUTPUT
-        echo '"macos-13",' >> $GITHUB_OUTPUT'
+        echo "macos-13", >> $GITHUB_OUTPUT'
         }}
         echo ']' >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJson(needs.action-setup.outputs.os) }}
-    runs-on: ${{ matrix.sys.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -29,12 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sys:
-        - os: ubuntu-latest-16-cores # x64
-        ${{ fromJSON(needs.action-setup.outputs.action-changed == 'true' && '
-        - os: ubuntu-jammy-16-cores-arm64 # ARM
-        - os: macos-13 # Intel
-        ' || '') }}
+        os: [
+          ubuntu-latest-16-cores,
+          ${{ needs.action-setup.outputs.action-changed == 'true' && 'ubuntu-jammy-16-cores-arm64,' }}
+          ${{ needs.action-setup.outputs.action-changed == 'true' && 'macos-13,' }}
+        ]
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -23,17 +23,16 @@ jobs:
         filters: |
           action:
           - 'action.yml'
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@v8
       id: os
       with:
         script: |
-          const actionChanged = '${{ steps.changes.outputs.action-changed }}' === 'true';
-          const osArray = ['ubuntu-latest-16-cores'];
-          if (actionChanged) {
-            osArray.push('ubuntu-jammy-16-cores-arm64');
-            osArray.push('macos-13');
+          const os = ['ubuntu-latest-16-cores'];
+          if ('${{ steps.changes.outputs.action-changed }}' === 'true') {
+            os.push('ubuntu-jammy-16-cores-arm64');
+            os.push('macos-13');
           }
-          core.setOutput('os', JSON.stringify(osArray));
+          core.setOutput('os', JSON.stringify(os));
         
 
   action-test:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -9,10 +9,10 @@ on:
         default: ''
 
 jobs:
-  action-setup:
+  action-setup-matrix:
     runs-on: ubuntu-latest
     outputs:
-      action-changed: ${{ steps.changes.outputs.action }}
+      os: ${{ steps.os.outputs.os }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -23,17 +23,25 @@ jobs:
         filters: |
           action:
           - 'action.yml'
+    - id: os
+      run: |
+        echo "os<<EOF" >> $GITHUB_OUTPUT
+        echo '[' >> $GITHUB_OUTPUT
+        echo '"ubuntu-latest-16-cores",' >> $GITHUB_OUTPUT
+        ${{ steps.changes.outputs.action-changed == 'true' &&
+        echo '"ubuntu-jammy-16-cores-arm64",' >> $GITHUB_OUTPUT
+        echo '"macos-13",' >> $GITHUB_OUTPUT
+        }}
+        echo ']' >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+        
 
   action-test:
     needs: setup
     strategy:
       fail-fast: false
       matrix:
-        os: [
-          ubuntu-latest-16-cores,
-          ${{ needs.action-setup.outputs.action-changed == 'true' && 'ubuntu-jammy-16-cores-arm64,' }}
-          ${{ needs.action-setup.outputs.action-changed == 'true' && 'macos-13,' }}
-        ]
+        os: ${{ fromJson(needs.setup.outputs.os) }}
     runs-on: ${{ matrix.sys.os }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -23,17 +23,17 @@ jobs:
         filters: |
           action:
           - 'action.yml'
-    - id: os
-      run: |
-        echo "os<<EOF" >> $GITHUB_OUTPUT
-        echo '[' >> $GITHUB_OUTPUT
-        echo '"ubuntu-latest-16-cores",' >> $GITHUB_OUTPUT
-        ${{ steps.changes.outputs.action-changed == 'true' &&
-        'echo "ubuntu-jammy-16-cores-arm64", >> $GITHUB_OUTPUT
-        echo "macos-13", >> $GITHUB_OUTPUT'
-        }}
-        echo ']' >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+    - uses: actions/github-script@v7
+      id: os
+      with:
+        script: |
+          const actionChanged = '${{ steps.changes.outputs.action-changed }}' === 'true';
+          const osArray = ['ubuntu-latest-16-cores'];
+          if (actionChanged) {
+            osArray.push('ubuntu-jammy-16-cores-arm64');
+            osArray.push('macos-13');
+          }
+          core.setOutput('os', JSON.stringify(osArray));
         
 
   action-test:

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       tag-prefix: ${{ steps.tag-prefix.outputs.tag-prefix }}
       tag-alias-prefix: ${{ steps.tag-prefix.outputs.tag-alias-prefix }}
+      action-changed: ${{ steps.changes.outputs.action }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -40,6 +41,12 @@ jobs:
         count="$(git rev-list HEAD --count --first-parent)"
         echo "tag-prefix=${pr_prefix}v${count}-" >> $GITHUB_OUTPUT
         echo "tag-alias-prefix=${pr_prefix}" >> $GITHUB_OUTPUT
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      id: changes
+      with:
+        filters: |
+          action:
+          - 'action.yml'
 
   latest:
     needs: [setup]
@@ -54,7 +61,12 @@ jobs:
 
   latest-action-test:
     needs: [setup, latest]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
+      || (
+        github.event.pull_request.head.repo.full_name == github.repository
+        && needs.setup.outputs.action-changed == 'true'
+      )
     uses: ./.github/workflows/action-test.yml
     with:
       tag: ${{ needs.setup.outputs.tag-prefix }}latest
@@ -72,7 +84,12 @@ jobs:
 
   testing-action-test:
     needs: [setup, testing]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
+      || (
+        github.event.pull_request.head.repo.full_name == github.repository
+        && needs.setup.outputs.action-changed == 'true'
+      )
     uses: ./.github/workflows/action-test.yml
     with:
       tag: ${{ needs.setup.outputs.tag-prefix }}testing

--- a/.github/workflows/build-start.yml
+++ b/.github/workflows/build-start.yml
@@ -29,7 +29,6 @@ jobs:
     outputs:
       tag-prefix: ${{ steps.tag-prefix.outputs.tag-prefix }}
       tag-alias-prefix: ${{ steps.tag-prefix.outputs.tag-alias-prefix }}
-      action-changed: ${{ steps.changes.outputs.action }}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -41,12 +40,6 @@ jobs:
         count="$(git rev-list HEAD --count --first-parent)"
         echo "tag-prefix=${pr_prefix}v${count}-" >> $GITHUB_OUTPUT
         echo "tag-alias-prefix=${pr_prefix}" >> $GITHUB_OUTPUT
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-      id: changes
-      with:
-        filters: |
-          action:
-          - 'action.yml'
 
   latest:
     needs: [setup]
@@ -63,10 +56,7 @@ jobs:
     needs: [setup, latest]
     if: |
       github.event_name == 'push' && github.ref == 'refs/heads/main'
-      || (
-        github.event.pull_request.head.repo.full_name == github.repository
-        && needs.setup.outputs.action-changed == 'true'
-      )
+      || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/action-test.yml
     with:
       tag: ${{ needs.setup.outputs.tag-prefix }}latest
@@ -86,10 +76,7 @@ jobs:
     needs: [setup, testing]
     if: |
       github.event_name == 'push' && github.ref == 'refs/heads/main'
-      || (
-        github.event.pull_request.head.repo.full_name == github.repository
-        && needs.setup.outputs.action-changed == 'true'
-      )
+      || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/action-test.yml
     with:
       tag: ${{ needs.setup.outputs.tag-prefix }}testing

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ env:
   # Cache ID is a value inserted into cache keys. Whenever changing the build
   # in a way that needs to use entirely new fresh builds, increment the number
   # by one so that all the keys become new.
-  CACHE_ID: 1
+  CACHE_ID: 3
   ARTIFACT_RETENTION_DAYS_FOR_IMAGE: 7
   ARTIFACT_RETENTION_DAYS_FOR_LOGS: 60
 


### PR DESCRIPTION
### What
Reduce the matrix for which OSes the action tests run on for PRs that do not change the action.

Also, make the action tests always run on the main branch push events.

  ### Why
  The action tests take a _long_ time to run on those additional OSes, but are fast on ubuntu.

The additional change to always run on main is so that we still find out if the action tests fail on any commit. Today the action tests don't run on main for some reason.