### PR TITLE
Fix horizon cache key in image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-horizon-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
+        key: image-${{ env.CACHE_ID }}-stellar-horizon-${{ inputs.arch }}-${{ needs.shas.outputs.horizon }}
     - name: Upload Stellar-Horizon Image
       if: steps.cache.outputs.cache-hit == 'true'
       uses: actions/upload-artifact@v4
@@ -176,7 +176,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: /tmp/image
-        key: image-stellar-horizon-${{ inputs.arch }}-${{ needs.shas.outputs.rpc }}
+        key: image-${{ env.CACHE_ID }}-stellar-horizon-${{ inputs.arch }}-${{ needs.shas.outputs.horizon }}
     - name: Checkout Quickstart for Horizon docker file
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
### What
  Update the cache key for the horizon image build to include CACHE_ID and use the horizon SHA.

  ### Why
  The cache key for the horizon image is missing the cache id that helps with invalidating all the images when needed. The cache key is also embedding the rpc sha instead of the horizon sha. That second part is a pretty bad bug, but it was only recently committed and the impact should be small.