### PR TITLE
Use Cheaper Runners in Action Test

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -24,6 +24,7 @@ jobs:
           action:
           - 'action.yml'
           - '.github/workflows/action-test.yml'
+        list-files: shell
     - uses: actions/github-script@v8
       id: os
       env:
@@ -36,7 +37,7 @@ jobs:
             os.push('macos-13');
           }
           core.setOutput('os', JSON.stringify(os));
-        
+    - run: echo "action-changed: ${{ steps.changes.outputs.action-changed }}"
 
   action-test:
     needs: action-setup

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -23,15 +23,16 @@ jobs:
         filters: |
           action:
           - 'action.yml'
+          - '.github/workflows/action-test.yml'
     - uses: actions/github-script@v8
       id: os
       env:
         ACTION_CHANGED: ${{ steps.changes.outputs.action-changed }}
       with:
         script: |
-          const os = ['ubuntu-latest-16-cores'];
+          const os = ['ubuntu-latest'];
           if (process.env.ACTION_CHANGED === 'true') {
-            os.push('ubuntu-jammy-16-cores-arm64');
+            os.push('ubuntu-24.04-arm');
             os.push('macos-13');
           }
           core.setOutput('os', JSON.stringify(os));

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -37,8 +37,6 @@ jobs:
             os.push('macos-13');
           }
           core.setOutput('os', JSON.stringify(os));
-    - run: echo "action-changed = ${{ steps.changes.outputs.action }}"
-    - run: echo "os = ${{ steps.os.outputs.os }}"
 
   action-test:
     needs: action-setup

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/github-script@v8
       id: os
       env:
-        ACTION_CHANGED: ${{ steps.changes.outputs.action-changed }}
+        ACTION_CHANGED: ${{ steps.changes.outputs.action }}
       with:
         script: |
           const os = ['ubuntu-latest'];
@@ -37,7 +37,8 @@ jobs:
             os.push('macos-13');
           }
           core.setOutput('os', JSON.stringify(os));
-    - run: echo "action-changed = ${{ steps.changes.outputs.action-changed }}"
+    - run: echo "action-changed = ${{ steps.changes.outputs.action }}"
+    - run: echo "os = ${{ steps.os.outputs.os }}"
 
   action-test:
     needs: action-setup

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -37,7 +37,7 @@ jobs:
             os.push('macos-13');
           }
           core.setOutput('os', JSON.stringify(os));
-    - run: echo "action-changed: ${{ steps.changes.outputs.action-changed }}"
+    - run: echo "action-changed = ${{ steps.changes.outputs.action-changed }}"
 
   action-test:
     needs: action-setup


### PR DESCRIPTION
### What
  Switch the action test workflow to use cheaper runners.

  ### Why
  Reduce costs associated with GitHub Actions. Make the wait time less because the cheaper runners are more available. I don't think these tests require the beefy runners.