### PR TITLE
Reduce test jobs that run for pubnet and testnet

### DIFF
--- a/.github/workflows/build-future.yml
+++ b/.github/workflows/build-future.yml
@@ -44,9 +44,9 @@ jobs:
       test_matrix: |
         {
           "network": ["local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
           "options": [""]
         }
 
@@ -69,9 +69,9 @@ jobs:
       test_matrix: |
         {
           "network": ["local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
           "options": [""]
         }
 

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -45,11 +45,14 @@ jobs:
       lab_ref: main
       test_matrix: |
         {
-          "network": ["pubnet", "local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
-          "options": [""]
+          "network": ["local"],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
+          "options": [""],
+          "include": [
+            { "network": "pubnet", "core": true, "horizon": true, "rpc": true }
+          ]
         }
 
   arm64:
@@ -70,11 +73,14 @@ jobs:
       lab_ref: main
       test_matrix: |
         {
-          "network": ["pubnet", "local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
-          "options": [""]
+          "network": ["local"],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
+          "options": [""],
+          "include": [
+            { "network": "pubnet", "core": true, "horizon": true, "rpc": true }
+          ]
         }
 
   manifest:

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -46,11 +46,15 @@ jobs:
       lab_ref: main
       test_matrix: |
         {
-          "network": ["testnet", "pubnet", "local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
-          "options": [""]
+          "network": ["local"],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
+          "options": [""],
+          "include": [
+            { "network": "testnet", "core": true, "horizon": true, "rpc": true },
+            { "network": "pubnet", "core": true, "horizon": true, "rpc": true }
+          ]
         }
 
   arm64:
@@ -71,11 +75,15 @@ jobs:
       lab_ref: main
       test_matrix: |
         {
-          "network": ["testnet", "pubnet", "local"],
-          "core": ["core", null],
-          "horizon": ["horizon", null],
-          "rpc": ["rpc", null],
-          "options": [""]
+          "network": ["local"],
+          "core": [true, false],
+          "horizon": [true, false],
+          "rpc": [true, false],
+          "options": [""],
+          "include": [
+            { "network": "testnet", "core": true, "horizon": true, "rpc": true },
+            { "network": "pubnet", "core": true, "horizon": true, "rpc": true }
+          ]
         }
 
   manifest:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -545,7 +545,7 @@ jobs:
         --name stellar
         $IMAGE
         --${{ matrix.network }}
-        --enable ${{ matrix.core }},${{ matrix.horizon }},${{ matrix.rpc }}
+        --enable ${{ matrix.core && 'core' }},${{ matrix.horizon && 'horizon' }},${{ matrix.rpc && 'rpc' }}
         ${{ matrix.options }}
     - name: Set up Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
### What
  Reduce test jobs that run for pubnet and testnet.

  ### Why
  The test jobs for pubnet and testnet are longer because they require syncing to public networks. This means they use more resources, make the overall build slower, and due to the external connectivity can fail sometimes slowing us down as we repeatedly try to rerun them. As long as we run all the variants of tests with the local network, there isn't as much value in running all the variants with pubnet and testnet. By running less variants of the tests we reduce random failures that often just affect one or two variants randomly.