### PR TITLE
SPIKE: Protocol 28 (CAP-0084)

### DIFF
--- a/images.json
+++ b/images.json
@@ -260,36 +260,37 @@
   {
     "tag": "nightly-next",
     "events": [
+      "pull_request",
       "push",
       "schedule"
     ],
     "config": {
-      "protocol_version_default": 27,
+      "protocol_version_default": 28,
       "horizon_skip_protocol_version_check": true
     },
     "deps": [
       {
         "name": "xdr",
-        "repo": "stellar/rs-stellar-xdr",
-        "ref": "main"
+        "repo": "sisuresh/rs-stellar-xdr",
+        "ref": "p28-cap-0084"
       },
       {
         "name": "core",
-        "repo": "stellar/stellar-core",
-        "ref": "master",
+        "repo": "sisuresh/stellar-core",
+        "ref": "p28-cap-0084",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
       },
       {
         "name": "rpc",
-        "repo": "stellar/stellar-rpc",
-        "ref": "protocol-next"
+        "repo": "sisuresh/stellar-rpc",
+        "ref": "p28-cap-0084"
       },
       {
         "name": "horizon",
-        "repo": "stellar/stellar-horizon",
-        "ref": "protocol-next",
+        "repo": "sisuresh/stellar-horizon",
+        "ref": "p28-cap-0084",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }
@@ -304,8 +305,8 @@
       },
       {
         "name": "lab",
-        "repo": "stellar/laboratory",
-        "ref": "main"
+        "repo": "sisuresh/laboratory",
+        "ref": "p28-cap-0084"
       },
       {
         "name": "galexie",


### PR DESCRIPTION
SPIKE bumping `nightly-next` in `images.json` to Protocol 28 (CAP-0084). Core (and all deps) build **from source** here, so this does **not** wait on any published `-vnext` deb/image.

## Changes
- `nightly-next.config.protocol_version_default`: 27 → 28 (`horizon_skip_protocol_version_check` kept).
- Repoint `nightly-next` deps to the CAP-0084 SPIKE branches on `sisuresh/*` @ `p28-cap-0084`: xdr, core, rpc, horizon, lab.
- Kept core `--enable-next-protocol-version-unsafe-for-production` and horizon `pkg` path.
- Added `pull_request` to `nightly-next.events` so CI actually builds this variant on the PR — **SPIKE-only, revert before non-draft merge.**
- `latest`/`testing`/`future`/`nightly` untouched.

## Deferred
- `friendbot` (@`main`) and `galexie` (@`protocol-next`) left unchanged — out of scope; galexie still pins `go-stellar-sdk@protocol-next` (risk to watch).
- Productionize: flip `repo`/`ref` back to `stellar/*` at tagged release, drop `pull_request` event, undraft.
- `etc/config-settings/` only covers up to p26; p28 Soroban limits fall back to nearest lower dir — not a blocker.

## Cross-links (P28 CAP-0084 chain)
stellar-xdr#307 · rs-stellar-xdr#552 · rs-soroban-env#1700 · rs-soroban-sdk#1924 · stellar-core#5337 · go-stellar-sdk#5961 · stellar-horizon#203 · stellar-rpc#837 · js-stellar-base#981 · js-stellar-sdk#1507 · js-stellar-xdr-json#59 · laboratory#2141
