### PR TITLE
SPIKE: Protocol 28 (CAP-0085)

### DIFF
--- a/images.json
+++ b/images.json
@@ -260,36 +260,37 @@
   {
     "tag": "nightly-next",
     "events": [
+      "pull_request",
       "push",
       "schedule"
     ],
     "config": {
-      "protocol_version_default": 27,
+      "protocol_version_default": 28,
       "horizon_skip_protocol_version_check": true
     },
     "deps": [
       {
         "name": "xdr",
-        "repo": "stellar/rs-stellar-xdr",
-        "ref": "main"
+        "repo": "sisuresh/rs-stellar-xdr",
+        "ref": "p28-cap-0085"
       },
       {
         "name": "core",
-        "repo": "stellar/stellar-core",
-        "ref": "master",
+        "repo": "sisuresh/stellar-core",
+        "ref": "p28-cap-0085",
         "options": {
           "configure_flags": "--disable-tests --enable-next-protocol-version-unsafe-for-production"
         }
       },
       {
         "name": "rpc",
-        "repo": "stellar/stellar-rpc",
-        "ref": "protocol-next"
+        "repo": "sisuresh/stellar-rpc",
+        "ref": "p28-cap-0085"
       },
       {
         "name": "horizon",
-        "repo": "stellar/stellar-horizon",
-        "ref": "protocol-next",
+        "repo": "sisuresh/stellar-horizon",
+        "ref": "p28-cap-0085",
         "options": {
           "pkg": "github.com/stellar/stellar-horizon"
         }
@@ -304,8 +305,8 @@
       },
       {
         "name": "lab",
-        "repo": "stellar/laboratory",
-        "ref": "main"
+        "repo": "sisuresh/laboratory",
+        "ref": "p28-cap-0085"
       },
       {
         "name": "galexie",


### PR DESCRIPTION
## Changes
- Point the `nightly-next` image at the CAP-0085 SPIKE fork branches (`sisuresh/*` @ `p28-cap-0085`): xdr, core, rpc, horizon, lab — built from source at protocol 28 (`--enable-next-protocol-version-unsafe-for-production`).
- `protocol_version_default: 27 → 28`; add `pull_request` to `nightly-next` events (build the SPIKE on PRs, mirroring the prior p28 SPIKE).
- `friendbot`, `galexie`, and all other image tags (`latest`/`testing`/`future`/`nightly`) left untouched.

## Deferred
- CI reds rooted in an upstream fork branch that doesn't yet build cleanly are upstream fixes (routed to that repo's `p28-cap-0085` PR), not Quickstart edits.

Upstream (canonical): stellar/stellar-xdr#308 · stellar/rs-soroban-env#1703
This run's SPIKE stack: stellar/rs-stellar-xdr#553 · stellar/rs-soroban-env#1704 · stellar/rs-soroban-sdk#1929 · stellar/stellar-core#5347 · stellar/go-stellar-sdk#5962 · stellar/stellar-horizon#205 · stellar/stellar-rpc#853 · stellar/js-stellar-base#982 · stellar/js-stellar-sdk#1525 · stellar/js-stellar-xdr-json#60 · stellar/laboratory#2154
