### PR TITLE
Bump stellar-cli github action to v27.0.0

### DIFF
--- a/.github/workflows/update-config-settings.yml
+++ b/.github/workflows/update-config-settings.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install stellar-cli
-      uses: stellar/stellar-cli@v26.1.0
+      uses: stellar/stellar-cli@v27.0.0
 
     - name: Update config settings
       id: update


### PR DESCRIPTION
> [!NOTE]
> Blocked by:
> - https://github.com/stellar/quickstart/issues/960
### What
Bump stellar-cli github action to v27.0.0.

### Why
So it is able to interact with the v27 networks. Nothing is urgently broken or incompatible, but it's good to keep it updated.