### PR TITLE
Bump pinned stellar-cli to v27.1.0

### DIFF
--- a/.github/workflows/update-config-settings.yml
+++ b/.github/workflows/update-config-settings.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install stellar-cli
-      uses: stellar/stellar-cli@v26.1.0
+      uses: stellar/stellar-cli@v27.1.0
 
     - name: Update config settings
       id: update


### PR DESCRIPTION
### What
Bump the stellar-cli version pinned in the Update Config Settings workflow from v26.1.0 to v27.1.0.

### Why
Testnet is now on protocol 27, but the pinned CLI only supports protocol 26, so the workflow's own guard has failed every weekly scheduled run for the past 9 weeks with "testnet is on protocol 27 but stellar-cli supports protocol 26; bump the pinned stellar-cli version".