### PR TITLE
Fail fast in tests when container reports unhealthy

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,11 @@ runs:
           if [ "$status" == "healthy" ]; then
             break
           fi
+          if [ "$status" == "unhealthy" ]; then
+            echo "::error::stellar container reported unhealthy, printing logs:"
+            docker logs stellar
+            exit 1
+          fi
           sleep 1;
           i=$((i + 1))
           if (( $i > 300 )); then


### PR DESCRIPTION
### What
Make the "Wait for container to be healthy" step in action.yml exit immediately with the container logs when docker reports the container as unhealthy, instead of only checking for "healthy" and looping forever otherwise.

### Why
A recent CI run hung for ~40 minutes before being cancelled because the wait loop never reacted to docker's `unhealthy` status. Docker will initially show a state of `starting`, then after many failed checks eventually move the container to `unhealthy`. If a container ends up in unhealthy it is unlikely to recover in the test so it should fail then.