### PR TITLE
Make tests more reliable

### DIFF
--- a/.github/workflows/internal-test.yml
+++ b/.github/workflows/internal-test.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   artifact_retention_days_for_logs: 60
-  timeout_multiplier: 8
+  timeout_multiplier: 16
 
 jobs:
 


### PR DESCRIPTION
### What

Double `timeout_multiplier` in the test workflow so the first attempt gets 16 minutes per test step instead of 8.

### Why

The testnet `core,rpc,horizon` job's horizon core-up test needs most of 8 minutes to finish captive core catchup, so ordinary variation tips the first attempt over the limit and the run only goes green after someone re-runs it, as happened in run 1325 where the step timed out at 8 minutes and then passed in 6m32s on the re-run.

For example:
- https://github.com/stellar/quickstart/actions/runs/32142963137