### PR TITLE
Attest images pushed by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,12 @@ jobs:
     if: ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     name: 5 push
     needs: [setup, build]
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+      statuses: write
     uses: ./.github/workflows/internal-push.yml
     with:
       sha: ${{ needs.setup.outputs.sha }}

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -91,13 +91,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -156,13 +156,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -210,13 +210,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -59,6 +59,8 @@ jobs:
       fail-fast: false
     name: 1 push (${{ matrix.tag }}, ${{ matrix.arch }})
     permissions:
+      attestations: write
+      id-token: write
       packages: write
       statuses: write
     runs-on: ubuntu-latest
@@ -87,6 +89,20 @@ jobs:
       run: >
         docker push
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
+    - name: Image Digest
+      id: digest
+      run: |
+        digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
+        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "could not determine digest of pushed image" >&2
+          exit 1
+        fi
+        echo "digest=$digest" | tee -a $GITHUB_OUTPUT
+    - name: Attest Image
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
+        subject-digest: ${{ steps.digest.outputs.digest }}
     - name: Post Status with Image Name
       uses: actions/github-script@v5
       with:
@@ -108,6 +124,8 @@ jobs:
       fail-fast: false
     name: 2 push manifest (${{ matrix.tag }})
     permissions:
+      attestations: write
+      id-token: write
       packages: write
       statuses: write
     runs-on: ubuntu-latest
@@ -137,6 +155,20 @@ jobs:
       run: >
         docker manifest push
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
+    - name: Image Digest
+      id: digest
+      run: |
+        digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
+        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "could not determine digest of pushed image" >&2
+          exit 1
+        fi
+        echo "digest=$digest" | tee -a $GITHUB_OUTPUT
+    - name: Attest Image
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
+        subject-digest: ${{ steps.digest.outputs.digest }}
     - uses: actions/github-script@v5
       with:
         script: |
@@ -157,6 +189,8 @@ jobs:
       fail-fast: false
     name: 3 push alias (${{ matrix.tag }})
     permissions:
+      attestations: write
+      id-token: write
       packages: write
       statuses: write
     runs-on: ubuntu-latest
@@ -176,6 +210,20 @@ jobs:
         docker buildx imagetools create -t
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }}
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
+    - name: Image Digest
+      id: digest
+      run: |
+        digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
+        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "could not determine digest of pushed image" >&2
+          exit 1
+        fi
+        echo "digest=$digest" | tee -a $GITHUB_OUTPUT
+    - name: Attest Image
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
+        subject-digest: ${{ steps.digest.outputs.digest }}
     - uses: actions/github-script@v5
       with:
         script: |

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -219,6 +219,10 @@ jobs:
           exit 1
         fi
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
+    # Redundant while the alias is a 1:1 copy of a manifest list, because
+    # imagetools create passes the original bytes and descriptor through and so
+    # the alias has the same digest as the manifest attested above. Kept so the
+    # alias tag stays attested if that ever stops holding.
     - name: Attest Image
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -91,13 +91,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -156,13 +156,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -210,13 +210,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/pull/977/merge'
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -187,8 +187,6 @@ jobs:
       fail-fast: false
     name: 3 push alias (${{ matrix.tag }})
     permissions:
-      attestations: write
-      id-token: write
       packages: write
       statuses: write
     runs-on: ubuntu-latest
@@ -208,19 +206,6 @@ jobs:
         docker buildx imagetools create -t
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }}
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
-    - name: Image Digest
-      id: digest
-      if: github.ref == 'refs/heads/main'
-      run: |
-        set -o pipefail
-        digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
-        echo "digest=$digest" | tee -a $GITHUB_OUTPUT
-    - name: Attest Image
-      if: github.ref == 'refs/heads/main'
-      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-      with:
-        subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
-        subject-digest: ${{ steps.digest.outputs.digest }}
     - uses: actions/github-script@v5
       with:
         script: |

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -92,11 +92,8 @@ jobs:
     - name: Image Digest
       id: digest
       run: |
+        set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
-        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-          echo "could not determine digest of pushed image" >&2
-          exit 1
-        fi
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -158,11 +155,8 @@ jobs:
     - name: Image Digest
       id: digest
       run: |
+        set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
-        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-          echo "could not determine digest of pushed image" >&2
-          exit 1
-        fi
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -213,11 +207,8 @@ jobs:
     - name: Image Digest
       id: digest
       run: |
+        set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
-        if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-          echo "could not determine digest of pushed image" >&2
-          exit 1
-        fi
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     # Redundant while the alias is a 1:1 copy of a manifest list, because
     # imagetools create passes the original bytes and descriptor through and so

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -91,11 +91,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -154,11 +156,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}
@@ -206,11 +210,13 @@ jobs:
         ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag }}
     - name: Image Digest
       id: digest
+      if: github.ref == 'refs/heads/main'
       run: |
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
     - name: Attest Image
+      if: github.ref == 'refs/heads/main'
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:
         subject-name: ${{ secrets.registry }}/${{ inputs.registry_repo }}

--- a/.github/workflows/internal-push.yml
+++ b/.github/workflows/internal-push.yml
@@ -210,10 +210,6 @@ jobs:
         set -o pipefail
         digest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' ${{ secrets.registry }}/${{ inputs.registry_repo }}:${{ steps.tag.outputs.tag-alias }} | jq -r '.digest')"
         echo "digest=$digest" | tee -a $GITHUB_OUTPUT
-    # Redundant while the alias is a 1:1 copy of a manifest list, because
-    # imagetools create passes the original bytes and descriptor through and so
-    # the alias has the same digest as the manifest attested above. Kept so the
-    # alias tag stays attested if that ever stops holding.
     - name: Attest Image
       uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
       with:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ the [`gh` CLI]:
 gh attestation verify oci://docker.io/stellar/quickstart:latest --repo stellar/quickstart
 ```
 
+The `gh` CLI must be authenticated, because the attestation is fetched from
+GitHub rather than from the registry.
+
 Attestations are only available for images built after attestation support was
 added to the build, and are not available for older images.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ All tags are published as multiplatform images supporting architectures:
 - `linux/amd46`
 - `linux/arm64`
 
+## Verifying Images
+
+Images are published with [build provenance attestations] signed by GitHub
+Actions, recording the workflow and commit that built them. Verify an image with
+the [`gh` CLI]:
+
+```
+gh attestation verify oci://docker.io/stellar/quickstart:latest --repo stellar/quickstart
+```
+
+Attestations are only available for images built after attestation support was
+added to the build, and are not available for older images.
+
+[build provenance attestations]: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
+[`gh` CLI]: https://cli.github.com
+
 ## Usage
 
 To use this project successfully, you should first decide a few things:


### PR DESCRIPTION
### What

Attest every image pushed from main with `actions/attest-build-provenance`, and document verifying an image with `gh attestation verify` in the README.

### Why

Images published by this repo had no way to be verified or linked back to the code that built them.

Close #648