### PR TITLE
Fix broken-pipe panic in update-config-settings

### DIFF
--- a/.scripts/update-config-settings
+++ b/.scripts/update-config-settings
@@ -30,13 +30,7 @@ fi
 # stellar-cli's major version tracks the protocol it supports. If testnet has
 # advanced beyond it, `stellar network settings` silently omits settings the
 # older XDR doesn't know about, so fail loudly to prompt bumping the pinned CLI.
-#
-# `stellar version` output is captured in full before piping to head/sed: piping
-# it directly to `head -n1` lets head close its end of the pipe as soon as it
-# has its line, which can race with `stellar` still writing its later lines and
-# make it panic on the resulting broken pipe.
-cli_version_output="$(stellar version)"
-cli_protocol="$(printf '%s\n' "$cli_version_output" | head -n1 | sed -E 's/^stellar ([0-9]+).*/\1/')"
+cli_protocol="$(stellar version --only-version-major)"
 if [ "$protocol" -gt "$cli_protocol" ]; then
   echo "error: testnet is on protocol $protocol but stellar-cli supports protocol $cli_protocol; bump the pinned stellar-cli version" >&2
   exit 1

--- a/.scripts/update-config-settings
+++ b/.scripts/update-config-settings
@@ -30,7 +30,13 @@ fi
 # stellar-cli's major version tracks the protocol it supports. If testnet has
 # advanced beyond it, `stellar network settings` silently omits settings the
 # older XDR doesn't know about, so fail loudly to prompt bumping the pinned CLI.
-cli_protocol="$(stellar version | head -n1 | sed -E 's/^stellar ([0-9]+).*/\1/')"
+#
+# `stellar version` output is captured in full before piping to head/sed: piping
+# it directly to `head -n1` lets head close its end of the pipe as soon as it
+# has its line, which can race with `stellar` still writing its later lines and
+# make it panic on the resulting broken pipe.
+cli_version_output="$(stellar version)"
+cli_protocol="$(printf '%s\n' "$cli_version_output" | head -n1 | sed -E 's/^stellar ([0-9]+).*/\1/')"
 if [ "$protocol" -gt "$cli_protocol" ]; then
   echo "error: testnet is on protocol $protocol but stellar-cli supports protocol $cli_protocol; bump the pinned stellar-cli version" >&2
   exit 1


### PR DESCRIPTION
### What
Read the CLI's major version with `stellar version --only-version-major` instead of piping `stellar version`'s full output through `head`/`sed`.

### Why
The "Update Config Settings" workflow [failed CI](https://github.com/stellar/quickstart/actions/runs/33390151480/job/99481678002#step:4:9) with a broken-pipe panic when `stellar version | head -n1 | sed ...` let `head` close its end of the pipe while `stellar` was still writing later lines:

```
thread 'main' (2314) panicked at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
```