### PR TITLE
Clean up stale build-deps targets from makefile phony list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__PHONY__: run logs console build build-deps build-deps-xdr build-deps-core build-deps-horizon build-deps-friendbot build-deps-rpc build-deps-lab test
+__PHONY__: run logs console build test
 
 CONTAINER_RUNTIME?=docker
 REVISION=$(shell git -c core.abbrev=no describe --always --exclude='*' --long --dirty)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-__PHONY__: run logs console build test
+.PHONY: run logs console build test
 
 CONTAINER_RUNTIME?=docker
 REVISION=$(shell git -c core.abbrev=no describe --always --exclude='*' --long --dirty)


### PR DESCRIPTION
### What
Trim the Makefile's phony target list down to the targets that actually exist.

### Why
The list named `build-deps`, `build-deps-*`, none of which are defined since the build process was changed into a single Dockerfile with multiple stages.