### PR TITLE
Bump stellar-cli to v28.0.0 for protocol 28

### DIFF
--- a/.github/workflows/auto-update-config-settings.yml
+++ b/.github/workflows/auto-update-config-settings.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install stellar-cli
-      uses: stellar/stellar-cli@v27.1.0
+      uses: stellar/stellar-cli@v28.0.0
 
     - name: Update config settings
       id: update


### PR DESCRIPTION
### What
Update stellar-cli to v28.0.0.

### Why
It is the latest release. Testnet is running p28.